### PR TITLE
demonstrate how to use a debug client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 equinix-metal.swagger.json.orig
+.vscode

--- a/README.MD
+++ b/README.MD
@@ -43,12 +43,10 @@ type FindProjectsParams struct {
 }
 ```
 
-There's HTTPCleint in the params and the client can maybe used for HTTP traffic logging, but it wouldn't be trivial.
+There's an `HTTPClient` in the params and the client can maybe used for isolated HTTP traffic logging.
 
 
 
 ## Notes
 
 - authentication struct must be passed to every function. All the generated functions have authWriter as an argument. I'm not sure if it's possible to set the auth header globally so that all the func use it. And I'm not sure if it's possible to remove the authWrite from the generated code.
-- there seems to be no simple way to print HTTP requests and responses in the generated client:
-  https://github.com/swagger-api/swagger-codegen/issues/5703

--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@ You can see usage of the generated code in the `examples` directory. In order to
 ```
 $ PACKET_AUTH_TOKEN=... go run examples/projects/projects.go
 [...]
-$ PACKET_AUTH_TOKEN=... go run examples/plans/plans.go
+$ cd examples/plans; PACKET_AUTH_TOKEN=... go run .
 ```
 
 ## Generated code

--- a/examples/plans/go.mod
+++ b/examples/plans/go.mod
@@ -1,0 +1,12 @@
+module github.com/t0mk/gometal/examples/plans
+
+go 1.14
+
+require (
+	github.com/go-openapi/runtime v0.19.26
+	github.com/go-openapi/strfmt v0.20.0
+	github.com/t0mk/gometal v0.0.0-20210124095926-212875b1b106
+	sigs.k8s.io/yaml v1.2.0
+)
+
+replace github.com/t0mk/gometal => ../..

--- a/examples/plans/go.sum
+++ b/examples/plans/go.sum
@@ -281,3 +281,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/examples/plans/plans.go
+++ b/examples/plans/plans.go
@@ -1,29 +1,41 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
 	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 	"github.com/t0mk/gometal/client"
+	"sigs.k8s.io/yaml"
 )
 
+func NewDebugClient(formats strfmt.Registry, cfg *client.TransportConfig) *client.MetalAPI {
+	// ensure nullable parameters have default
+	if cfg == nil {
+		cfg = client.DefaultTransportConfig()
+	}
+
+	// create transport and client
+	transport := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)
+	transport.SetDebug(true)
+	return client.New(transport, formats)
+}
+
 func main() {
-	c := client.NewHTTPClient(nil)
+	c := NewDebugClient(nil, nil)
 	auth := httptransport.APIKeyAuth("X-Auth-Token", "header", os.Getenv("PACKET_AUTH_TOKEN"))
+
 	r, err := c.Plans.FindPlans(nil, auth)
 
 	if err != nil {
 		panic(err)
 	}
 
-	s, err := json.Marshal(r)
+	s, err := yaml.Marshal(r.GetPayload().Plans)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf(string(s))
-	log.Println(r)
+	fmt.Println(string(s))
 }


### PR DESCRIPTION
Fixes #2 

By demonstrating how to incorporate a custom RoundTripper, we can enable built-in transport debugging or use a custom roundtripper that injects request or response data.

Borrowed ideas from https://github.com/go-swagger/go-swagger/issues/2015#issuecomment-510735058

I used `sigs.k8s.io/yaml` instead of `gopkg.in/yaml.v3` because the serialization is better (`hour: 0.5` instead of `"0.5"`, `count` is numeric, `available_in` instead of `availablein`)