### PR TITLE
Consistent builds

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -2,8 +2,10 @@
 curl -o equinix-metal.swagger.json https://api.equinix.com/metal/v1/api-docs
 for a in *patch; do patch -p0 < "$a"; done
 
-# https://github.com/go-swagger/go-swagger/releases/latest
-swagger generate client \
+SWAGGER="docker run --rm -it --env GOPATH=/go -v `pwd`:/go/src -w /go/src quay.io/goswagger/swagger"
+# binary available at https://github.com/go-swagger/go-swagger/releases/latest
+# we use Docker to keep builds consistent between users
+$SWAGGER generate client \
 	--model-package types \
 	--additional-initialism bgp \
 	--additional-initialism vpn \


### PR DESCRIPTION
Update gen.sh to provide consistent builds by removing variability of which version of go-swagger was used.

This could be improved by fixing the go-swagger version to a known version, but I am leaving that out under the presumption that for now we will get the latest version on each run.