### PR TITLE
Deprecate subnet fields

### DIFF
--- a/client/batches/batches_client.go
+++ b/client/batches/batches_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteBatch(params *DeleteBatchParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteBatchNoContent, error)
+	DeleteBatch(params *DeleteBatchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteBatchNoContent, error)
 
-	FindBatchByID(params *FindBatchByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindBatchByIDOK, error)
+	FindBatchByID(params *FindBatchByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBatchByIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Deletes the Batch.
 */
-func (a *Client) DeleteBatch(params *DeleteBatchParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteBatchNoContent, error) {
+func (a *Client) DeleteBatch(params *DeleteBatchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteBatchNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteBatchParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteBatch",
 		Method:             "DELETE",
 		PathPattern:        "/batches/{id}",
@@ -57,7 +59,12 @@ func (a *Client) DeleteBatch(params *DeleteBatchParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) DeleteBatch(params *DeleteBatchParams, authInfo runtime.ClientA
 
   Returns a Batch
 */
-func (a *Client) FindBatchByID(params *FindBatchByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindBatchByIDOK, error) {
+func (a *Client) FindBatchByID(params *FindBatchByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBatchByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindBatchByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findBatchById",
 		Method:             "GET",
 		PathPattern:        "/batches/{id}",
@@ -94,7 +100,12 @@ func (a *Client) FindBatchByID(params *FindBatchByIDParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/bgp/bgp_client.go
+++ b/client/bgp/bgp_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteBGPSession(params *DeleteBGPSessionParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteBGPSessionNoContent, error)
+	DeleteBGPSession(params *DeleteBGPSessionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteBGPSessionNoContent, error)
 
-	FindBGPSessionByID(params *FindBGPSessionByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindBGPSessionByIDOK, error)
+	FindBGPSessionByID(params *FindBGPSessionByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBGPSessionByIDOK, error)
 
-	UpdateBGPSession(params *UpdateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateBGPSessionOK, error)
+	UpdateBGPSession(params *UpdateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateBGPSessionOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Deletes the BGP session.
 */
-func (a *Client) DeleteBGPSession(params *DeleteBGPSessionParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteBGPSessionNoContent, error) {
+func (a *Client) DeleteBGPSession(params *DeleteBGPSessionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteBGPSessionNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteBGPSessionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteBgpSession",
 		Method:             "DELETE",
 		PathPattern:        "/bgp/sessions/{id}",
@@ -59,7 +61,12 @@ func (a *Client) DeleteBGPSession(params *DeleteBGPSessionParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) DeleteBGPSession(params *DeleteBGPSessionParams, authInfo runti
 
   Returns a BGP session
 */
-func (a *Client) FindBGPSessionByID(params *FindBGPSessionByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindBGPSessionByIDOK, error) {
+func (a *Client) FindBGPSessionByID(params *FindBGPSessionByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBGPSessionByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindBGPSessionByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findBgpSessionById",
 		Method:             "GET",
 		PathPattern:        "/bgp/sessions/{id}",
@@ -96,7 +102,12 @@ func (a *Client) FindBGPSessionByID(params *FindBGPSessionByIDParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) FindBGPSessionByID(params *FindBGPSessionByIDParams, authInfo r
 
   Updates the BGP session by either enabling or disabling the default route functionality.
 */
-func (a *Client) UpdateBGPSession(params *UpdateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateBGPSessionOK, error) {
+func (a *Client) UpdateBGPSession(params *UpdateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateBGPSessionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateBGPSessionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateBgpSession",
 		Method:             "PUT",
 		PathPattern:        "/bgp/sessions/{id}",
@@ -133,7 +143,12 @@ func (a *Client) UpdateBGPSession(params *UpdateBGPSessionParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/capacity/capacity_client.go
+++ b/client/capacity/capacity_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CheckCapacity(params *CheckCapacityParams, authInfo runtime.ClientAuthInfoWriter) (*CheckCapacityOK, error)
+	CheckCapacity(params *CheckCapacityParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CheckCapacityOK, error)
 
-	FindCapacity(params *FindCapacityParams, authInfo runtime.ClientAuthInfoWriter) (*FindCapacityOK, error)
+	FindCapacity(params *FindCapacityParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindCapacityOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -47,13 +50,12 @@ Response:
 ]
 ```
 */
-func (a *Client) CheckCapacity(params *CheckCapacityParams, authInfo runtime.ClientAuthInfoWriter) (*CheckCapacityOK, error) {
+func (a *Client) CheckCapacity(params *CheckCapacityParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CheckCapacityOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCheckCapacityParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "checkCapacity",
 		Method:             "POST",
 		PathPattern:        "/capacity",
@@ -65,7 +67,12 @@ func (a *Client) CheckCapacity(params *CheckCapacityParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -84,13 +91,12 @@ func (a *Client) CheckCapacity(params *CheckCapacityParams, authInfo runtime.Cli
 
   Returns a list of facilities and plans with their current capacity.
 */
-func (a *Client) FindCapacity(params *FindCapacityParams, authInfo runtime.ClientAuthInfoWriter) (*FindCapacityOK, error) {
+func (a *Client) FindCapacity(params *FindCapacityParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindCapacityOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindCapacityParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findCapacity",
 		Method:             "GET",
 		PathPattern:        "/capacity",
@@ -102,7 +108,12 @@ func (a *Client) FindCapacity(params *FindCapacityParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/connections/connections_client.go
+++ b/client/connections/connections_client.go
@@ -25,35 +25,38 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateConnectionPortVirtualCircuit(params *CreateConnectionPortVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*CreateConnectionPortVirtualCircuitOK, error)
+	CreateConnectionPortVirtualCircuit(params *CreateConnectionPortVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateConnectionPortVirtualCircuitOK, error)
 
-	CreateOrganizationInterconnection(params *CreateOrganizationInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationInterconnectionCreated, error)
+	CreateOrganizationInterconnection(params *CreateOrganizationInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationInterconnectionCreated, error)
 
-	CreateProjectInterconnection(params *CreateProjectInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectInterconnectionCreated, error)
+	CreateProjectInterconnection(params *CreateProjectInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectInterconnectionCreated, error)
 
-	DeleteInterconnection(params *DeleteInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteInterconnectionAccepted, error)
+	DeleteInterconnection(params *DeleteInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteInterconnectionAccepted, error)
 
-	DeleteVirtualCircuit(params *DeleteVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVirtualCircuitAccepted, error)
+	DeleteVirtualCircuit(params *DeleteVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVirtualCircuitAccepted, error)
 
-	GetConnectionPort(params *GetConnectionPortParams, authInfo runtime.ClientAuthInfoWriter) (*GetConnectionPortOK, error)
+	GetConnectionPort(params *GetConnectionPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetConnectionPortOK, error)
 
-	GetInterconnection(params *GetInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*GetInterconnectionOK, error)
+	GetInterconnection(params *GetInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetInterconnectionOK, error)
 
-	GetVirtualCircuit(params *GetVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*GetVirtualCircuitOK, error)
+	GetVirtualCircuit(params *GetVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetVirtualCircuitOK, error)
 
-	ListConnectionPortVirtualCircuits(params *ListConnectionPortVirtualCircuitsParams, authInfo runtime.ClientAuthInfoWriter) (*ListConnectionPortVirtualCircuitsOK, error)
+	ListConnectionPortVirtualCircuits(params *ListConnectionPortVirtualCircuitsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListConnectionPortVirtualCircuitsOK, error)
 
-	ListConnectionPorts(params *ListConnectionPortsParams, authInfo runtime.ClientAuthInfoWriter) (*ListConnectionPortsOK, error)
+	ListConnectionPorts(params *ListConnectionPortsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListConnectionPortsOK, error)
 
-	OrganizationListInterconnections(params *OrganizationListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter) (*OrganizationListInterconnectionsOK, error)
+	OrganizationListInterconnections(params *OrganizationListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*OrganizationListInterconnectionsOK, error)
 
-	ProjectListInterconnections(params *ProjectListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter) (*ProjectListInterconnectionsOK, error)
+	ProjectListInterconnections(params *ProjectListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ProjectListInterconnectionsOK, error)
 
-	UpdateInterconnection(params *UpdateInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateInterconnectionOK, error)
+	UpdateInterconnection(params *UpdateInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateInterconnectionOK, error)
 
-	UpdateVirtualCircuit(params *UpdateVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateVirtualCircuitOK, *UpdateVirtualCircuitAccepted, error)
+	UpdateVirtualCircuit(params *UpdateVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateVirtualCircuitOK, *UpdateVirtualCircuitAccepted, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -63,13 +66,12 @@ type ClientService interface {
 
   Create a new Virtual Circuit on a dedicated connection using a Virtual Network record and an NNI VLAN value.
 */
-func (a *Client) CreateConnectionPortVirtualCircuit(params *CreateConnectionPortVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*CreateConnectionPortVirtualCircuitOK, error) {
+func (a *Client) CreateConnectionPortVirtualCircuit(params *CreateConnectionPortVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateConnectionPortVirtualCircuitOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateConnectionPortVirtualCircuitParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createConnectionPortVirtualCircuit",
 		Method:             "POST",
 		PathPattern:        "/connections/{connection_id}/ports/{port_id}/virtual-circuits",
@@ -81,7 +83,12 @@ func (a *Client) CreateConnectionPortVirtualCircuit(params *CreateConnectionPort
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -100,13 +107,12 @@ func (a *Client) CreateConnectionPortVirtualCircuit(params *CreateConnectionPort
 
   Creates a new connection request. A Project ID must be specified in the request body for connections on shared ports.
 */
-func (a *Client) CreateOrganizationInterconnection(params *CreateOrganizationInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationInterconnectionCreated, error) {
+func (a *Client) CreateOrganizationInterconnection(params *CreateOrganizationInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationInterconnectionCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateOrganizationInterconnectionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createOrganizationInterconnection",
 		Method:             "POST",
 		PathPattern:        "/organizations/{organization_id}/connections",
@@ -118,7 +124,12 @@ func (a *Client) CreateOrganizationInterconnection(params *CreateOrganizationInt
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -137,13 +148,12 @@ func (a *Client) CreateOrganizationInterconnection(params *CreateOrganizationInt
 
   Creates a new connection request
 */
-func (a *Client) CreateProjectInterconnection(params *CreateProjectInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectInterconnectionCreated, error) {
+func (a *Client) CreateProjectInterconnection(params *CreateProjectInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectInterconnectionCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateProjectInterconnectionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createProjectInterconnection",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/connections",
@@ -155,7 +165,12 @@ func (a *Client) CreateProjectInterconnection(params *CreateProjectInterconnecti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -174,13 +189,12 @@ func (a *Client) CreateProjectInterconnection(params *CreateProjectInterconnecti
 
   Delete a connection, its associated ports and virtual circuits.
 */
-func (a *Client) DeleteInterconnection(params *DeleteInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteInterconnectionAccepted, error) {
+func (a *Client) DeleteInterconnection(params *DeleteInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteInterconnectionAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteInterconnectionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteInterconnection",
 		Method:             "DELETE",
 		PathPattern:        "/connections/{connection_id}",
@@ -192,7 +206,12 @@ func (a *Client) DeleteInterconnection(params *DeleteInterconnectionParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -211,13 +230,12 @@ func (a *Client) DeleteInterconnection(params *DeleteInterconnectionParams, auth
 
   Delete a virtual circuit from a dedicated port.
 */
-func (a *Client) DeleteVirtualCircuit(params *DeleteVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVirtualCircuitAccepted, error) {
+func (a *Client) DeleteVirtualCircuit(params *DeleteVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVirtualCircuitAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteVirtualCircuitParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteVirtualCircuit",
 		Method:             "DELETE",
 		PathPattern:        "/virtual-circuits/{id}",
@@ -229,7 +247,12 @@ func (a *Client) DeleteVirtualCircuit(params *DeleteVirtualCircuitParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -248,13 +271,12 @@ func (a *Client) DeleteVirtualCircuit(params *DeleteVirtualCircuitParams, authIn
 
   Get the details of an connection port.
 */
-func (a *Client) GetConnectionPort(params *GetConnectionPortParams, authInfo runtime.ClientAuthInfoWriter) (*GetConnectionPortOK, error) {
+func (a *Client) GetConnectionPort(params *GetConnectionPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetConnectionPortOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetConnectionPortParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getConnectionPort",
 		Method:             "GET",
 		PathPattern:        "/connections/{connection_id}/ports/{id}",
@@ -266,7 +288,12 @@ func (a *Client) GetConnectionPort(params *GetConnectionPortParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -285,13 +312,12 @@ func (a *Client) GetConnectionPort(params *GetConnectionPortParams, authInfo run
 
   Get the details of a connection
 */
-func (a *Client) GetInterconnection(params *GetInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*GetInterconnectionOK, error) {
+func (a *Client) GetInterconnection(params *GetInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetInterconnectionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetInterconnectionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getInterconnection",
 		Method:             "GET",
 		PathPattern:        "/connections/{connection_id}",
@@ -303,7 +329,12 @@ func (a *Client) GetInterconnection(params *GetInterconnectionParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -322,13 +353,12 @@ func (a *Client) GetInterconnection(params *GetInterconnectionParams, authInfo r
 
   Get the details of a virtual circuit
 */
-func (a *Client) GetVirtualCircuit(params *GetVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*GetVirtualCircuitOK, error) {
+func (a *Client) GetVirtualCircuit(params *GetVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetVirtualCircuitOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetVirtualCircuitParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getVirtualCircuit",
 		Method:             "GET",
 		PathPattern:        "/virtual-circuits/{id}",
@@ -340,7 +370,12 @@ func (a *Client) GetVirtualCircuit(params *GetVirtualCircuitParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -359,13 +394,12 @@ func (a *Client) GetVirtualCircuit(params *GetVirtualCircuitParams, authInfo run
 
   List the virtual circuit record(s) associatiated with a particular connection port.
 */
-func (a *Client) ListConnectionPortVirtualCircuits(params *ListConnectionPortVirtualCircuitsParams, authInfo runtime.ClientAuthInfoWriter) (*ListConnectionPortVirtualCircuitsOK, error) {
+func (a *Client) ListConnectionPortVirtualCircuits(params *ListConnectionPortVirtualCircuitsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListConnectionPortVirtualCircuitsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListConnectionPortVirtualCircuitsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listConnectionPortVirtualCircuits",
 		Method:             "GET",
 		PathPattern:        "/connections/{connection_id}/ports/{port_id}/virtual-circuits",
@@ -377,7 +411,12 @@ func (a *Client) ListConnectionPortVirtualCircuits(params *ListConnectionPortVir
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -396,13 +435,12 @@ func (a *Client) ListConnectionPortVirtualCircuits(params *ListConnectionPortVir
 
   List the ports associated to an connection.
 */
-func (a *Client) ListConnectionPorts(params *ListConnectionPortsParams, authInfo runtime.ClientAuthInfoWriter) (*ListConnectionPortsOK, error) {
+func (a *Client) ListConnectionPorts(params *ListConnectionPortsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListConnectionPortsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListConnectionPortsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listConnectionPorts",
 		Method:             "GET",
 		PathPattern:        "/connections/{connection_id}/ports",
@@ -414,7 +452,12 @@ func (a *Client) ListConnectionPorts(params *ListConnectionPortsParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -433,13 +476,12 @@ func (a *Client) ListConnectionPorts(params *ListConnectionPortsParams, authInfo
 
   List the connections belonging to the organization
 */
-func (a *Client) OrganizationListInterconnections(params *OrganizationListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter) (*OrganizationListInterconnectionsOK, error) {
+func (a *Client) OrganizationListInterconnections(params *OrganizationListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*OrganizationListInterconnectionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewOrganizationListInterconnectionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "organizationListInterconnections",
 		Method:             "GET",
 		PathPattern:        "/organizations/{organization_id}/connections",
@@ -451,7 +493,12 @@ func (a *Client) OrganizationListInterconnections(params *OrganizationListInterc
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -470,13 +517,12 @@ func (a *Client) OrganizationListInterconnections(params *OrganizationListInterc
 
   List the connections belonging to the project
 */
-func (a *Client) ProjectListInterconnections(params *ProjectListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter) (*ProjectListInterconnectionsOK, error) {
+func (a *Client) ProjectListInterconnections(params *ProjectListInterconnectionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ProjectListInterconnectionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewProjectListInterconnectionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "projectListInterconnections",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/connections",
@@ -488,7 +534,12 @@ func (a *Client) ProjectListInterconnections(params *ProjectListInterconnections
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -507,13 +558,12 @@ func (a *Client) ProjectListInterconnections(params *ProjectListInterconnections
 
   Update the details of a connection
 */
-func (a *Client) UpdateInterconnection(params *UpdateInterconnectionParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateInterconnectionOK, error) {
+func (a *Client) UpdateInterconnection(params *UpdateInterconnectionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateInterconnectionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateInterconnectionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateInterconnection",
 		Method:             "PUT",
 		PathPattern:        "/connections/{connection_id}",
@@ -525,7 +575,12 @@ func (a *Client) UpdateInterconnection(params *UpdateInterconnectionParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -544,13 +599,12 @@ func (a *Client) UpdateInterconnection(params *UpdateInterconnectionParams, auth
 
   Update the details of a virtual circuit.
 */
-func (a *Client) UpdateVirtualCircuit(params *UpdateVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateVirtualCircuitOK, *UpdateVirtualCircuitAccepted, error) {
+func (a *Client) UpdateVirtualCircuit(params *UpdateVirtualCircuitParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateVirtualCircuitOK, *UpdateVirtualCircuitAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateVirtualCircuitParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateVirtualCircuit",
 		Method:             "PUT",
 		PathPattern:        "/virtual-circuits/{id}",
@@ -562,7 +616,12 @@ func (a *Client) UpdateVirtualCircuit(params *UpdateVirtualCircuitParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/devices/devices_client.go
+++ b/client/devices/devices_client.go
@@ -25,39 +25,42 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateBGPSession(params *CreateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter) (*CreateBGPSessionOK, *CreateBGPSessionCreated, error)
+	CreateBGPSession(params *CreateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateBGPSessionOK, *CreateBGPSessionCreated, error)
 
-	CreateDeviceBatch(params *CreateDeviceBatchParams, authInfo runtime.ClientAuthInfoWriter) (*CreateDeviceBatchCreated, error)
+	CreateDeviceBatch(params *CreateDeviceBatchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateDeviceBatchCreated, error)
 
-	CreateIPAssignment(params *CreateIPAssignmentParams, authInfo runtime.ClientAuthInfoWriter) (*CreateIPAssignmentCreated, error)
+	CreateIPAssignment(params *CreateIPAssignmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateIPAssignmentCreated, error)
 
-	DeleteDevice(params *DeleteDeviceParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteDeviceNoContent, error)
+	DeleteDevice(params *DeleteDeviceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteDeviceNoContent, error)
 
-	FindBGPSessions(params *FindBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter) (*FindBGPSessionsOK, error)
+	FindBGPSessions(params *FindBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBGPSessionsOK, error)
 
-	FindDeviceByID(params *FindDeviceByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceByIDOK, error)
+	FindDeviceByID(params *FindDeviceByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceByIDOK, error)
 
-	FindDeviceCustomdata(params *FindDeviceCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceCustomdataOK, error)
+	FindDeviceCustomdata(params *FindDeviceCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceCustomdataOK, error)
 
-	FindDeviceUsages(params *FindDeviceUsagesParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceUsagesOK, error)
+	FindDeviceUsages(params *FindDeviceUsagesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceUsagesOK, error)
 
-	FindIPAssignmentCustomdata(params *FindIPAssignmentCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAssignmentCustomdataOK, error)
+	FindIPAssignmentCustomdata(params *FindIPAssignmentCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAssignmentCustomdataOK, error)
 
-	FindIPAssignments(params *FindIPAssignmentsParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAssignmentsOK, error)
+	FindIPAssignments(params *FindIPAssignmentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAssignmentsOK, error)
 
-	FindInstanceBandwidth(params *FindInstanceBandwidthParams, authInfo runtime.ClientAuthInfoWriter) (*FindInstanceBandwidthOK, error)
+	FindInstanceBandwidth(params *FindInstanceBandwidthParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindInstanceBandwidthOK, error)
 
-	FindProjectUsage(params *FindProjectUsageParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectUsageOK, error)
+	FindProjectUsage(params *FindProjectUsageParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectUsageOK, error)
 
-	FindTraffic(params *FindTrafficParams, authInfo runtime.ClientAuthInfoWriter) (*FindTrafficOK, error)
+	FindTraffic(params *FindTrafficParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindTrafficOK, error)
 
-	GetBGPNeighborData(params *GetBGPNeighborDataParams, authInfo runtime.ClientAuthInfoWriter) (*GetBGPNeighborDataOK, error)
+	GetBGPNeighborData(params *GetBGPNeighborDataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetBGPNeighborDataOK, error)
 
-	PerformAction(params *PerformActionParams, authInfo runtime.ClientAuthInfoWriter) (*PerformActionAccepted, error)
+	PerformAction(params *PerformActionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PerformActionAccepted, error)
 
-	UpdateDevice(params *UpdateDeviceParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateDeviceOK, error)
+	UpdateDevice(params *UpdateDeviceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateDeviceOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -67,13 +70,12 @@ type ClientService interface {
 
   Creates a BGP session.
 */
-func (a *Client) CreateBGPSession(params *CreateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter) (*CreateBGPSessionOK, *CreateBGPSessionCreated, error) {
+func (a *Client) CreateBGPSession(params *CreateBGPSessionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateBGPSessionOK, *CreateBGPSessionCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateBGPSessionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createBgpSession",
 		Method:             "POST",
 		PathPattern:        "/devices/{id}/bgp/sessions",
@@ -85,7 +87,12 @@ func (a *Client) CreateBGPSession(params *CreateBGPSessionParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -141,13 +148,12 @@ For example, `{ "ip_addresses": [..., {"address_family": 4, "public": true, "ip_
 
 To access a server without public IPs, you can use our Out-of-Band console access (SOS) or use another server with public IPs as a proxy.
 */
-func (a *Client) CreateDeviceBatch(params *CreateDeviceBatchParams, authInfo runtime.ClientAuthInfoWriter) (*CreateDeviceBatchCreated, error) {
+func (a *Client) CreateDeviceBatch(params *CreateDeviceBatchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateDeviceBatchCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateDeviceBatchParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createDeviceBatch",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/devices/batch",
@@ -159,7 +165,12 @@ func (a *Client) CreateDeviceBatch(params *CreateDeviceBatchParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -178,13 +189,12 @@ func (a *Client) CreateDeviceBatch(params *CreateDeviceBatchParams, authInfo run
 
   Creates an ip assignment for a device.
 */
-func (a *Client) CreateIPAssignment(params *CreateIPAssignmentParams, authInfo runtime.ClientAuthInfoWriter) (*CreateIPAssignmentCreated, error) {
+func (a *Client) CreateIPAssignment(params *CreateIPAssignmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateIPAssignmentCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateIPAssignmentParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createIPAssignment",
 		Method:             "POST",
 		PathPattern:        "/devices/{id}/ips",
@@ -196,7 +206,12 @@ func (a *Client) CreateIPAssignment(params *CreateIPAssignmentParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -215,13 +230,12 @@ func (a *Client) CreateIPAssignment(params *CreateIPAssignmentParams, authInfo r
 
   Deletes a device and deprovisions it in our datacenter.
 */
-func (a *Client) DeleteDevice(params *DeleteDeviceParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteDeviceNoContent, error) {
+func (a *Client) DeleteDevice(params *DeleteDeviceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteDeviceNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteDeviceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteDevice",
 		Method:             "DELETE",
 		PathPattern:        "/devices/{id}",
@@ -233,7 +247,12 @@ func (a *Client) DeleteDevice(params *DeleteDeviceParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -252,13 +271,12 @@ func (a *Client) DeleteDevice(params *DeleteDeviceParams, authInfo runtime.Clien
 
   Provides a listing of available BGP sessions for the device.
 */
-func (a *Client) FindBGPSessions(params *FindBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter) (*FindBGPSessionsOK, error) {
+func (a *Client) FindBGPSessions(params *FindBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBGPSessionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindBGPSessionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findBgpSessions",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/bgp/sessions",
@@ -270,7 +288,12 @@ func (a *Client) FindBGPSessions(params *FindBGPSessionsParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -290,13 +313,12 @@ func (a *Client) FindBGPSessions(params *FindBGPSessionsParams, authInfo runtime
   Type-specific options (such as facility for baremetal devices) will be included as part of the main data structure.
                          State value can be one of: active inactive queued or provisioning
 */
-func (a *Client) FindDeviceByID(params *FindDeviceByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceByIDOK, error) {
+func (a *Client) FindDeviceByID(params *FindDeviceByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindDeviceByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findDeviceById",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}",
@@ -308,7 +330,12 @@ func (a *Client) FindDeviceByID(params *FindDeviceByIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -327,13 +354,12 @@ func (a *Client) FindDeviceByID(params *FindDeviceByIDParams, authInfo runtime.C
 
   Provides the custom metadata stored for this instance in json format
 */
-func (a *Client) FindDeviceCustomdata(params *FindDeviceCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceCustomdataOK, error) {
+func (a *Client) FindDeviceCustomdata(params *FindDeviceCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindDeviceCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findDeviceCustomdata",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/customdata",
@@ -345,7 +371,12 @@ func (a *Client) FindDeviceCustomdata(params *FindDeviceCustomdataParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -364,13 +395,12 @@ func (a *Client) FindDeviceCustomdata(params *FindDeviceCustomdataParams, authIn
 
   Returns all usages for a device.
 */
-func (a *Client) FindDeviceUsages(params *FindDeviceUsagesParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceUsagesOK, error) {
+func (a *Client) FindDeviceUsages(params *FindDeviceUsagesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceUsagesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindDeviceUsagesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findDeviceUsages",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/usages",
@@ -382,7 +412,12 @@ func (a *Client) FindDeviceUsages(params *FindDeviceUsagesParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -401,13 +436,12 @@ func (a *Client) FindDeviceUsages(params *FindDeviceUsagesParams, authInfo runti
 
   Provides the custom metadata stored for this IP Assignment in json format
 */
-func (a *Client) FindIPAssignmentCustomdata(params *FindIPAssignmentCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAssignmentCustomdataOK, error) {
+func (a *Client) FindIPAssignmentCustomdata(params *FindIPAssignmentCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAssignmentCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPAssignmentCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPAssignmentCustomdata",
 		Method:             "GET",
 		PathPattern:        "/devices/{instance_id}/ips/{id}/customdata",
@@ -419,7 +453,12 @@ func (a *Client) FindIPAssignmentCustomdata(params *FindIPAssignmentCustomdataPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -438,13 +477,12 @@ func (a *Client) FindIPAssignmentCustomdata(params *FindIPAssignmentCustomdataPa
 
   Returns all ip assignments for a device.
 */
-func (a *Client) FindIPAssignments(params *FindIPAssignmentsParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAssignmentsOK, error) {
+func (a *Client) FindIPAssignments(params *FindIPAssignmentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAssignmentsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPAssignmentsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPAssignments",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/ips",
@@ -456,7 +494,12 @@ func (a *Client) FindIPAssignments(params *FindIPAssignmentsParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -475,13 +518,12 @@ func (a *Client) FindIPAssignments(params *FindIPAssignmentsParams, authInfo run
 
   Retrieve an instance bandwidth for a given period of time.
 */
-func (a *Client) FindInstanceBandwidth(params *FindInstanceBandwidthParams, authInfo runtime.ClientAuthInfoWriter) (*FindInstanceBandwidthOK, error) {
+func (a *Client) FindInstanceBandwidth(params *FindInstanceBandwidthParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindInstanceBandwidthOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindInstanceBandwidthParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findInstanceBandwidth",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/bandwidth",
@@ -493,7 +535,12 @@ func (a *Client) FindInstanceBandwidth(params *FindInstanceBandwidthParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -512,13 +559,12 @@ func (a *Client) FindInstanceBandwidth(params *FindInstanceBandwidthParams, auth
 
   Returns all usages for a project.
 */
-func (a *Client) FindProjectUsage(params *FindProjectUsageParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectUsageOK, error) {
+func (a *Client) FindProjectUsage(params *FindProjectUsageParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectUsageOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectUsageParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectUsage",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/usages",
@@ -530,7 +576,12 @@ func (a *Client) FindProjectUsage(params *FindProjectUsageParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -549,13 +600,12 @@ func (a *Client) FindProjectUsage(params *FindProjectUsageParams, authInfo runti
 
   Returns traffic for a specific device.
 */
-func (a *Client) FindTraffic(params *FindTrafficParams, authInfo runtime.ClientAuthInfoWriter) (*FindTrafficOK, error) {
+func (a *Client) FindTraffic(params *FindTrafficParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindTrafficOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindTrafficParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findTraffic",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/traffic",
@@ -567,7 +617,12 @@ func (a *Client) FindTraffic(params *FindTrafficParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -586,13 +641,12 @@ func (a *Client) FindTraffic(params *FindTrafficParams, authInfo runtime.ClientA
 
   Provides a summary of the BGP neighbor data associated to the BGP sessions for this device.
 */
-func (a *Client) GetBGPNeighborData(params *GetBGPNeighborDataParams, authInfo runtime.ClientAuthInfoWriter) (*GetBGPNeighborDataOK, error) {
+func (a *Client) GetBGPNeighborData(params *GetBGPNeighborDataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetBGPNeighborDataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetBGPNeighborDataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getBgpNeighborData",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/bgp/neighbors",
@@ -604,7 +658,12 @@ func (a *Client) GetBGPNeighborData(params *GetBGPNeighborDataParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -623,13 +682,12 @@ func (a *Client) GetBGPNeighborData(params *GetBGPNeighborDataParams, authInfo r
 
   Performs an action for the given device.  Possible actions include: power_on, power_off, reboot, reinstall, and rescue (reboot the device into rescue OS.)
 */
-func (a *Client) PerformAction(params *PerformActionParams, authInfo runtime.ClientAuthInfoWriter) (*PerformActionAccepted, error) {
+func (a *Client) PerformAction(params *PerformActionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PerformActionAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPerformActionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "performAction",
 		Method:             "POST",
 		PathPattern:        "/devices/{id}/actions",
@@ -641,7 +699,12 @@ func (a *Client) PerformAction(params *PerformActionParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -660,13 +723,12 @@ func (a *Client) PerformAction(params *PerformActionParams, authInfo runtime.Cli
 
   Updates the device.
 */
-func (a *Client) UpdateDevice(params *UpdateDeviceParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateDeviceOK, error) {
+func (a *Client) UpdateDevice(params *UpdateDeviceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateDeviceOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateDeviceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateDevice",
 		Method:             "PUT",
 		PathPattern:        "/devices/{id}",
@@ -678,7 +740,12 @@ func (a *Client) UpdateDevice(params *UpdateDeviceParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/emails/emails_client.go
+++ b/client/emails/emails_client.go
@@ -25,15 +25,18 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateEmail(params *CreateEmailParams, authInfo runtime.ClientAuthInfoWriter) (*CreateEmailCreated, error)
+	CreateEmail(params *CreateEmailParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateEmailCreated, error)
 
-	DeleteEmail(params *DeleteEmailParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEmailNoContent, error)
+	DeleteEmail(params *DeleteEmailParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteEmailNoContent, error)
 
-	FindEmailByID(params *FindEmailByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindEmailByIDOK, error)
+	FindEmailByID(params *FindEmailByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEmailByIDOK, error)
 
-	UpdateEmail(params *UpdateEmailParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateEmailOK, error)
+	UpdateEmail(params *UpdateEmailParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateEmailOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,13 +46,12 @@ type ClientService interface {
 
   Add a new email address to the current user.
 */
-func (a *Client) CreateEmail(params *CreateEmailParams, authInfo runtime.ClientAuthInfoWriter) (*CreateEmailCreated, error) {
+func (a *Client) CreateEmail(params *CreateEmailParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateEmailCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateEmailParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createEmail",
 		Method:             "POST",
 		PathPattern:        "/emails",
@@ -61,7 +63,12 @@ func (a *Client) CreateEmail(params *CreateEmailParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +87,12 @@ func (a *Client) CreateEmail(params *CreateEmailParams, authInfo runtime.ClientA
 
   Deletes the email.
 */
-func (a *Client) DeleteEmail(params *DeleteEmailParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEmailNoContent, error) {
+func (a *Client) DeleteEmail(params *DeleteEmailParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteEmailNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteEmailParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteEmail",
 		Method:             "DELETE",
 		PathPattern:        "/emails/{id}",
@@ -98,7 +104,12 @@ func (a *Client) DeleteEmail(params *DeleteEmailParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +128,12 @@ func (a *Client) DeleteEmail(params *DeleteEmailParams, authInfo runtime.ClientA
 
   Provides one of the user’s emails.
 */
-func (a *Client) FindEmailByID(params *FindEmailByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindEmailByIDOK, error) {
+func (a *Client) FindEmailByID(params *FindEmailByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEmailByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindEmailByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findEmailById",
 		Method:             "GET",
 		PathPattern:        "/emails/{id}",
@@ -135,7 +145,12 @@ func (a *Client) FindEmailByID(params *FindEmailByIDParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -154,13 +169,12 @@ func (a *Client) FindEmailByID(params *FindEmailByIDParams, authInfo runtime.Cli
 
   Updates the email.
 */
-func (a *Client) UpdateEmail(params *UpdateEmailParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateEmailOK, error) {
+func (a *Client) UpdateEmail(params *UpdateEmailParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateEmailOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateEmailParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateEmail",
 		Method:             "PUT",
 		PathPattern:        "/emails/{id}",
@@ -172,7 +186,12 @@ func (a *Client) UpdateEmail(params *UpdateEmailParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/events/events_client.go
+++ b/client/events/events_client.go
@@ -25,25 +25,28 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindConnectionEvents(params *FindConnectionEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindConnectionEventsOK, error)
+	FindConnectionEvents(params *FindConnectionEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindConnectionEventsOK, error)
 
-	FindConnectionPortEvents(params *FindConnectionPortEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindConnectionPortEventsOK, error)
+	FindConnectionPortEvents(params *FindConnectionPortEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindConnectionPortEventsOK, error)
 
-	FindDeviceEvents(params *FindDeviceEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceEventsOK, error)
+	FindDeviceEvents(params *FindDeviceEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceEventsOK, error)
 
-	FindEventByID(params *FindEventByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindEventByIDOK, error)
+	FindEventByID(params *FindEventByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEventByIDOK, error)
 
-	FindEvents(params *FindEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindEventsOK, error)
+	FindEvents(params *FindEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEventsOK, error)
 
-	FindOrganizationEvents(params *FindOrganizationEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationEventsOK, error)
+	FindOrganizationEvents(params *FindOrganizationEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationEventsOK, error)
 
-	FindProjectEvents(params *FindProjectEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectEventsOK, error)
+	FindProjectEvents(params *FindProjectEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectEventsOK, error)
 
-	FindVirtualCircuitEvents(params *FindVirtualCircuitEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVirtualCircuitEventsOK, error)
+	FindVirtualCircuitEvents(params *FindVirtualCircuitEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVirtualCircuitEventsOK, error)
 
-	FindVolumeEvents(params *FindVolumeEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeEventsOK, error)
+	FindVolumeEvents(params *FindVolumeEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeEventsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -53,13 +56,12 @@ type ClientService interface {
 
   Returns a list of the connection events
 */
-func (a *Client) FindConnectionEvents(params *FindConnectionEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindConnectionEventsOK, error) {
+func (a *Client) FindConnectionEvents(params *FindConnectionEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindConnectionEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindConnectionEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findConnectionEvents",
 		Method:             "GET",
 		PathPattern:        "/connections/{connection_id}/events",
@@ -71,7 +73,12 @@ func (a *Client) FindConnectionEvents(params *FindConnectionEventsParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -90,13 +97,12 @@ func (a *Client) FindConnectionEvents(params *FindConnectionEventsParams, authIn
 
   Returns a list of the connection port events
 */
-func (a *Client) FindConnectionPortEvents(params *FindConnectionPortEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindConnectionPortEventsOK, error) {
+func (a *Client) FindConnectionPortEvents(params *FindConnectionPortEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindConnectionPortEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindConnectionPortEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findConnectionPortEvents",
 		Method:             "GET",
 		PathPattern:        "/connections/{connection_id}/ports/{id}/events",
@@ -108,7 +114,12 @@ func (a *Client) FindConnectionPortEvents(params *FindConnectionPortEventsParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +138,12 @@ func (a *Client) FindConnectionPortEvents(params *FindConnectionPortEventsParams
 
   Returns a list of events pertaining to a specific device
 */
-func (a *Client) FindDeviceEvents(params *FindDeviceEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceEventsOK, error) {
+func (a *Client) FindDeviceEvents(params *FindDeviceEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindDeviceEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findDeviceEvents",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/events",
@@ -145,7 +155,12 @@ func (a *Client) FindDeviceEvents(params *FindDeviceEventsParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -164,13 +179,12 @@ func (a *Client) FindDeviceEvents(params *FindDeviceEventsParams, authInfo runti
 
   Returns a single event if the user has access
 */
-func (a *Client) FindEventByID(params *FindEventByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindEventByIDOK, error) {
+func (a *Client) FindEventByID(params *FindEventByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEventByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindEventByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findEventById",
 		Method:             "GET",
 		PathPattern:        "/events/{id}",
@@ -182,7 +196,12 @@ func (a *Client) FindEventByID(params *FindEventByIDParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -201,13 +220,12 @@ func (a *Client) FindEventByID(params *FindEventByIDParams, authInfo runtime.Cli
 
   Returns a list of the current user’s events
 */
-func (a *Client) FindEvents(params *FindEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindEventsOK, error) {
+func (a *Client) FindEvents(params *FindEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findEvents",
 		Method:             "GET",
 		PathPattern:        "/events",
@@ -219,7 +237,12 @@ func (a *Client) FindEvents(params *FindEventsParams, authInfo runtime.ClientAut
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +261,12 @@ func (a *Client) FindEvents(params *FindEventsParams, authInfo runtime.ClientAut
 
   Returns a list of events for a single organization
 */
-func (a *Client) FindOrganizationEvents(params *FindOrganizationEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationEventsOK, error) {
+func (a *Client) FindOrganizationEvents(params *FindOrganizationEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationEvents",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/events",
@@ -256,7 +278,12 @@ func (a *Client) FindOrganizationEvents(params *FindOrganizationEventsParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -275,13 +302,12 @@ func (a *Client) FindOrganizationEvents(params *FindOrganizationEventsParams, au
 
   Returns a list of events for a single project
 */
-func (a *Client) FindProjectEvents(params *FindProjectEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectEventsOK, error) {
+func (a *Client) FindProjectEvents(params *FindProjectEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectEvents",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/events",
@@ -293,7 +319,12 @@ func (a *Client) FindProjectEvents(params *FindProjectEventsParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -312,13 +343,12 @@ func (a *Client) FindProjectEvents(params *FindProjectEventsParams, authInfo run
 
   Returns a list of the virtual circuit events
 */
-func (a *Client) FindVirtualCircuitEvents(params *FindVirtualCircuitEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVirtualCircuitEventsOK, error) {
+func (a *Client) FindVirtualCircuitEvents(params *FindVirtualCircuitEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVirtualCircuitEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVirtualCircuitEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVirtualCircuitEvents",
 		Method:             "GET",
 		PathPattern:        "/virtual-circuit/{id}/events",
@@ -330,7 +360,12 @@ func (a *Client) FindVirtualCircuitEvents(params *FindVirtualCircuitEventsParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -349,13 +384,12 @@ func (a *Client) FindVirtualCircuitEvents(params *FindVirtualCircuitEventsParams
 
   Returns a list of the current volume’s events
 */
-func (a *Client) FindVolumeEvents(params *FindVolumeEventsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeEventsOK, error) {
+func (a *Client) FindVolumeEvents(params *FindVolumeEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumeEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumeEvents",
 		Method:             "GET",
 		PathPattern:        "/volumes/{id}/events",
@@ -367,7 +401,12 @@ func (a *Client) FindVolumeEvents(params *FindVolumeEventsParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/facilities/facilities_client.go
+++ b/client/facilities/facilities_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindFacilities(params *FindFacilitiesParams, authInfo runtime.ClientAuthInfoWriter) (*FindFacilitiesOK, error)
+	FindFacilities(params *FindFacilitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindFacilitiesOK, error)
 
-	FindFacilitiesByOrganization(params *FindFacilitiesByOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*FindFacilitiesByOrganizationOK, error)
+	FindFacilitiesByOrganization(params *FindFacilitiesByOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindFacilitiesByOrganizationOK, error)
 
-	FindFacilitiesByProject(params *FindFacilitiesByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindFacilitiesByProjectOK, error)
+	FindFacilitiesByProject(params *FindFacilitiesByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindFacilitiesByProjectOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Provides a listing of available datacenters where you can provision Packet devices.
 */
-func (a *Client) FindFacilities(params *FindFacilitiesParams, authInfo runtime.ClientAuthInfoWriter) (*FindFacilitiesOK, error) {
+func (a *Client) FindFacilities(params *FindFacilitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindFacilitiesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindFacilitiesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findFacilities",
 		Method:             "GET",
 		PathPattern:        "/facilities",
@@ -59,7 +61,12 @@ func (a *Client) FindFacilities(params *FindFacilitiesParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) FindFacilities(params *FindFacilitiesParams, authInfo runtime.C
 
   Returns a listing of available datacenters for the given organization
 */
-func (a *Client) FindFacilitiesByOrganization(params *FindFacilitiesByOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*FindFacilitiesByOrganizationOK, error) {
+func (a *Client) FindFacilitiesByOrganization(params *FindFacilitiesByOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindFacilitiesByOrganizationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindFacilitiesByOrganizationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findFacilitiesByOrganization",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/facilities",
@@ -96,7 +102,12 @@ func (a *Client) FindFacilitiesByOrganization(params *FindFacilitiesByOrganizati
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) FindFacilitiesByOrganization(params *FindFacilitiesByOrganizati
 
   Returns a listing of available datacenters for the given project
 */
-func (a *Client) FindFacilitiesByProject(params *FindFacilitiesByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindFacilitiesByProjectOK, error) {
+func (a *Client) FindFacilitiesByProject(params *FindFacilitiesByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindFacilitiesByProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindFacilitiesByProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findFacilitiesByProject",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/facilities",
@@ -133,7 +143,12 @@ func (a *Client) FindFacilitiesByProject(params *FindFacilitiesByProjectParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/hardware_reservations/hardware_reservations_client.go
+++ b/client/hardware_reservations/hardware_reservations_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	PostHardwareReservationsIDMove(params *PostHardwareReservationsIDMoveParams, authInfo runtime.ClientAuthInfoWriter) (*PostHardwareReservationsIDMoveCreated, error)
+	PostHardwareReservationsIDMove(params *PostHardwareReservationsIDMoveParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostHardwareReservationsIDMoveCreated, error)
 
-	FindHardwareReservationByID(params *FindHardwareReservationByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindHardwareReservationByIDOK, error)
+	FindHardwareReservationByID(params *FindHardwareReservationByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindHardwareReservationByIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Move a hardware reservation to another project
 */
-func (a *Client) PostHardwareReservationsIDMove(params *PostHardwareReservationsIDMoveParams, authInfo runtime.ClientAuthInfoWriter) (*PostHardwareReservationsIDMoveCreated, error) {
+func (a *Client) PostHardwareReservationsIDMove(params *PostHardwareReservationsIDMoveParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostHardwareReservationsIDMoveCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostHardwareReservationsIDMoveParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostHardwareReservationsIDMove",
 		Method:             "POST",
 		PathPattern:        "/hardware-reservations/{id}/move",
@@ -57,7 +59,12 @@ func (a *Client) PostHardwareReservationsIDMove(params *PostHardwareReservations
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) PostHardwareReservationsIDMove(params *PostHardwareReservations
 
   Returns a single hardware reservation
 */
-func (a *Client) FindHardwareReservationByID(params *FindHardwareReservationByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindHardwareReservationByIDOK, error) {
+func (a *Client) FindHardwareReservationByID(params *FindHardwareReservationByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindHardwareReservationByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindHardwareReservationByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findHardwareReservationById",
 		Method:             "GET",
 		PathPattern:        "/hardware-reservations/{id}",
@@ -94,7 +100,12 @@ func (a *Client) FindHardwareReservationByID(params *FindHardwareReservationByID
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/incidents/incidents_client.go
+++ b/client/incidents/incidents_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetIncidents(params *GetIncidentsParams, authInfo runtime.ClientAuthInfoWriter) (*GetIncidentsOK, error)
+	GetIncidents(params *GetIncidentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetIncidentsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -37,13 +40,12 @@ type ClientService interface {
 
   Retrieve the number of incidents.
 */
-func (a *Client) GetIncidents(params *GetIncidentsParams, authInfo runtime.ClientAuthInfoWriter) (*GetIncidentsOK, error) {
+func (a *Client) GetIncidents(params *GetIncidentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetIncidentsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetIncidentsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetIncidents",
 		Method:             "GET",
 		PathPattern:        "/incidents",
@@ -55,7 +57,12 @@ func (a *Client) GetIncidents(params *GetIncidentsParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/internet_gateways/internet_gateways_client.go
+++ b/client/internet_gateways/internet_gateways_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateInternetGateway(params *CreateInternetGatewayParams, authInfo runtime.ClientAuthInfoWriter) (*CreateInternetGatewayCreated, error)
+	CreateInternetGateway(params *CreateInternetGatewayParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateInternetGatewayCreated, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -37,13 +40,12 @@ type ClientService interface {
 
   Creates an internet gateway.
 */
-func (a *Client) CreateInternetGateway(params *CreateInternetGatewayParams, authInfo runtime.ClientAuthInfoWriter) (*CreateInternetGatewayCreated, error) {
+func (a *Client) CreateInternetGateway(params *CreateInternetGatewayParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateInternetGatewayCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateInternetGatewayParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createInternetGateway",
 		Method:             "POST",
 		PathPattern:        "/virtual-networks/{id}/internet-gateways",
@@ -55,7 +57,12 @@ func (a *Client) CreateInternetGateway(params *CreateInternetGatewayParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/invitations/invitations_client.go
+++ b/client/invitations/invitations_client.go
@@ -25,23 +25,26 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AcceptInvitation(params *AcceptInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*AcceptInvitationOK, error)
+	AcceptInvitation(params *AcceptInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AcceptInvitationOK, error)
 
-	CreateOrganizationInvitation(params *CreateOrganizationInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationInvitationCreated, error)
+	CreateOrganizationInvitation(params *CreateOrganizationInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationInvitationCreated, error)
 
-	CreateProjectInvitation(params *CreateProjectInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectInvitationCreated, error)
+	CreateProjectInvitation(params *CreateProjectInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectInvitationCreated, error)
 
-	DeclineInvitation(params *DeclineInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*DeclineInvitationNoContent, error)
+	DeclineInvitation(params *DeclineInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeclineInvitationNoContent, error)
 
-	FindInvitationByID(params *FindInvitationByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindInvitationByIDOK, error)
+	FindInvitationByID(params *FindInvitationByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindInvitationByIDOK, error)
 
-	FindInvitations(params *FindInvitationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindInvitationsOK, error)
+	FindInvitations(params *FindInvitationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindInvitationsOK, error)
 
-	FindOrganizationInvitations(params *FindOrganizationInvitationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationInvitationsOK, error)
+	FindOrganizationInvitations(params *FindOrganizationInvitationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationInvitationsOK, error)
 
-	FindProjectInvitations(params *FindProjectInvitationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectInvitationsOK, error)
+	FindProjectInvitations(params *FindProjectInvitationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectInvitationsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -51,13 +54,12 @@ type ClientService interface {
 
   Accept an invitation.
 */
-func (a *Client) AcceptInvitation(params *AcceptInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*AcceptInvitationOK, error) {
+func (a *Client) AcceptInvitation(params *AcceptInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AcceptInvitationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAcceptInvitationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "acceptInvitation",
 		Method:             "PUT",
 		PathPattern:        "/invitations/{id}",
@@ -69,7 +71,12 @@ func (a *Client) AcceptInvitation(params *AcceptInvitationParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -89,13 +96,12 @@ func (a *Client) AcceptInvitation(params *AcceptInvitationParams, authInfo runti
   In order to add a user to an organization, they must first be invited.
 To invite to several projects the parameter `projects_ids:[a,b,c]` can be used
 */
-func (a *Client) CreateOrganizationInvitation(params *CreateOrganizationInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationInvitationCreated, error) {
+func (a *Client) CreateOrganizationInvitation(params *CreateOrganizationInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationInvitationCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateOrganizationInvitationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createOrganizationInvitation",
 		Method:             "POST",
 		PathPattern:        "/organizations/{id}/invitations",
@@ -107,7 +113,12 @@ func (a *Client) CreateOrganizationInvitation(params *CreateOrganizationInvitati
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -126,13 +137,12 @@ func (a *Client) CreateOrganizationInvitation(params *CreateOrganizationInvitati
 
   In order to add a user to a project, they must first be invited.
 */
-func (a *Client) CreateProjectInvitation(params *CreateProjectInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectInvitationCreated, error) {
+func (a *Client) CreateProjectInvitation(params *CreateProjectInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectInvitationCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateProjectInvitationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createProjectInvitation",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/invitations",
@@ -144,7 +154,12 @@ func (a *Client) CreateProjectInvitation(params *CreateProjectInvitationParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -163,13 +178,12 @@ func (a *Client) CreateProjectInvitation(params *CreateProjectInvitationParams, 
 
   Decline an invitation.
 */
-func (a *Client) DeclineInvitation(params *DeclineInvitationParams, authInfo runtime.ClientAuthInfoWriter) (*DeclineInvitationNoContent, error) {
+func (a *Client) DeclineInvitation(params *DeclineInvitationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeclineInvitationNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeclineInvitationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "declineInvitation",
 		Method:             "DELETE",
 		PathPattern:        "/invitations/{id}",
@@ -181,7 +195,12 @@ func (a *Client) DeclineInvitation(params *DeclineInvitationParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -200,13 +219,12 @@ func (a *Client) DeclineInvitation(params *DeclineInvitationParams, authInfo run
 
   Returns a single invitation. (It include the `invitable` to maintain backward compatibility but will be removed soon)
 */
-func (a *Client) FindInvitationByID(params *FindInvitationByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindInvitationByIDOK, error) {
+func (a *Client) FindInvitationByID(params *FindInvitationByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindInvitationByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindInvitationByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findInvitationById",
 		Method:             "GET",
 		PathPattern:        "/invitations/{id}",
@@ -218,7 +236,12 @@ func (a *Client) FindInvitationByID(params *FindInvitationByIDParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -237,13 +260,12 @@ func (a *Client) FindInvitationByID(params *FindInvitationByIDParams, authInfo r
 
   Returns all invitations in current user.
 */
-func (a *Client) FindInvitations(params *FindInvitationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindInvitationsOK, error) {
+func (a *Client) FindInvitations(params *FindInvitationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindInvitationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindInvitationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findInvitations",
 		Method:             "GET",
 		PathPattern:        "/invitations",
@@ -255,7 +277,12 @@ func (a *Client) FindInvitations(params *FindInvitationsParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -274,13 +301,12 @@ func (a *Client) FindInvitations(params *FindInvitationsParams, authInfo runtime
 
   Returns all invitations in an organization.
 */
-func (a *Client) FindOrganizationInvitations(params *FindOrganizationInvitationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationInvitationsOK, error) {
+func (a *Client) FindOrganizationInvitations(params *FindOrganizationInvitationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationInvitationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationInvitationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationInvitations",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/invitations",
@@ -292,7 +318,12 @@ func (a *Client) FindOrganizationInvitations(params *FindOrganizationInvitations
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -311,13 +342,12 @@ func (a *Client) FindOrganizationInvitations(params *FindOrganizationInvitations
 
   Returns all invitations in a project.
 */
-func (a *Client) FindProjectInvitations(params *FindProjectInvitationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectInvitationsOK, error) {
+func (a *Client) FindProjectInvitations(params *FindProjectInvitationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectInvitationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectInvitationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectInvitations",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/invitations",
@@ -329,7 +359,12 @@ func (a *Client) FindProjectInvitations(params *FindProjectInvitationsParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/ip_addresses/ip_addresses_client.go
+++ b/client/ip_addresses/ip_addresses_client.go
@@ -25,15 +25,18 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteIPAddress(params *DeleteIPAddressParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteIPAddressNoContent, error)
+	DeleteIPAddress(params *DeleteIPAddressParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteIPAddressNoContent, error)
 
-	FindIPAddressByID(params *FindIPAddressByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAddressByIDOK, error)
+	FindIPAddressByID(params *FindIPAddressByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAddressByIDOK, error)
 
-	FindIPAddressCustomdata(params *FindIPAddressCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAddressCustomdataOK, error)
+	FindIPAddressCustomdata(params *FindIPAddressCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAddressCustomdataOK, error)
 
-	FindIPAvailabilities(params *FindIPAvailabilitiesParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAvailabilitiesOK, error)
+	FindIPAvailabilities(params *FindIPAvailabilitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAvailabilitiesOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,13 +46,12 @@ type ClientService interface {
 
   Note! This call can be used to un-assign an IP assignment or delete an IP reservation. Un-assign an IP address record. Use the assignment UUID you get after attaching the IP. This will remove the relationship between an IP and the device and will make the IP address available to be assigned to another device. Delete and IP reservation. Use the reservation UUID you get after adding the IP to the project. This will permanently delete the IP block reservation from the project.
 */
-func (a *Client) DeleteIPAddress(params *DeleteIPAddressParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteIPAddressNoContent, error) {
+func (a *Client) DeleteIPAddress(params *DeleteIPAddressParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteIPAddressNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteIPAddressParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteIPAddress",
 		Method:             "DELETE",
 		PathPattern:        "/ips/{id}",
@@ -61,7 +63,12 @@ func (a *Client) DeleteIPAddress(params *DeleteIPAddressParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +87,12 @@ func (a *Client) DeleteIPAddress(params *DeleteIPAddressParams, authInfo runtime
 
   Returns a single ip address if the user has access.
 */
-func (a *Client) FindIPAddressByID(params *FindIPAddressByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAddressByIDOK, error) {
+func (a *Client) FindIPAddressByID(params *FindIPAddressByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAddressByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPAddressByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPAddressById",
 		Method:             "GET",
 		PathPattern:        "/ips/{id}",
@@ -98,7 +104,12 @@ func (a *Client) FindIPAddressByID(params *FindIPAddressByIDParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +128,12 @@ func (a *Client) FindIPAddressByID(params *FindIPAddressByIDParams, authInfo run
 
   Provides the custom metadata stored for this IP Reservation or IP Assignment in json format
 */
-func (a *Client) FindIPAddressCustomdata(params *FindIPAddressCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAddressCustomdataOK, error) {
+func (a *Client) FindIPAddressCustomdata(params *FindIPAddressCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAddressCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPAddressCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPAddressCustomdata",
 		Method:             "GET",
 		PathPattern:        "/ips/{id}/customdata",
@@ -135,7 +145,12 @@ func (a *Client) FindIPAddressCustomdata(params *FindIPAddressCustomdataParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -154,13 +169,12 @@ func (a *Client) FindIPAddressCustomdata(params *FindIPAddressCustomdataParams, 
 
   Provides a list of IP resevations for a single project.
 */
-func (a *Client) FindIPAvailabilities(params *FindIPAvailabilitiesParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPAvailabilitiesOK, error) {
+func (a *Client) FindIPAvailabilities(params *FindIPAvailabilitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPAvailabilitiesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPAvailabilitiesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPAvailabilities",
 		Method:             "GET",
 		PathPattern:        "/ips/{id}/available",
@@ -172,7 +186,12 @@ func (a *Client) FindIPAvailabilities(params *FindIPAvailabilitiesParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/licenses/licenses_client.go
+++ b/client/licenses/licenses_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteLicense(params *DeleteLicenseParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteLicenseNoContent, error)
+	DeleteLicense(params *DeleteLicenseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteLicenseNoContent, error)
 
-	FindLicenseByID(params *FindLicenseByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindLicenseByIDOK, error)
+	FindLicenseByID(params *FindLicenseByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindLicenseByIDOK, error)
 
-	UpdateLicense(params *UpdateLicenseParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateLicenseOK, error)
+	UpdateLicense(params *UpdateLicenseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateLicenseOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Deletes a license.
 */
-func (a *Client) DeleteLicense(params *DeleteLicenseParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteLicenseNoContent, error) {
+func (a *Client) DeleteLicense(params *DeleteLicenseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteLicenseNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteLicenseParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteLicense",
 		Method:             "DELETE",
 		PathPattern:        "/licenses/{id}",
@@ -59,7 +61,12 @@ func (a *Client) DeleteLicense(params *DeleteLicenseParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) DeleteLicense(params *DeleteLicenseParams, authInfo runtime.Cli
 
   Returns a license
 */
-func (a *Client) FindLicenseByID(params *FindLicenseByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindLicenseByIDOK, error) {
+func (a *Client) FindLicenseByID(params *FindLicenseByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindLicenseByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindLicenseByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findLicenseById",
 		Method:             "GET",
 		PathPattern:        "/licenses/{id}",
@@ -96,7 +102,12 @@ func (a *Client) FindLicenseByID(params *FindLicenseByIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) FindLicenseByID(params *FindLicenseByIDParams, authInfo runtime
 
   Updates the license.
 */
-func (a *Client) UpdateLicense(params *UpdateLicenseParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateLicenseOK, error) {
+func (a *Client) UpdateLicense(params *UpdateLicenseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateLicenseOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateLicenseParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateLicense",
 		Method:             "PUT",
 		PathPattern:        "/licenses/{id}",
@@ -133,7 +143,12 @@ func (a *Client) UpdateLicense(params *UpdateLicenseParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/market/market_client.go
+++ b/client/market/market_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindSpotMarketPrices(params *FindSpotMarketPricesParams, authInfo runtime.ClientAuthInfoWriter) (*FindSpotMarketPricesOK, error)
+	FindSpotMarketPrices(params *FindSpotMarketPricesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSpotMarketPricesOK, error)
 
-	FindSpotMarketPricesHistory(params *FindSpotMarketPricesHistoryParams, authInfo runtime.ClientAuthInfoWriter) (*FindSpotMarketPricesHistoryOK, error)
+	FindSpotMarketPricesHistory(params *FindSpotMarketPricesHistoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSpotMarketPricesHistoryOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Get Equinix Metal current spot market prices.
 */
-func (a *Client) FindSpotMarketPrices(params *FindSpotMarketPricesParams, authInfo runtime.ClientAuthInfoWriter) (*FindSpotMarketPricesOK, error) {
+func (a *Client) FindSpotMarketPrices(params *FindSpotMarketPricesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSpotMarketPricesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindSpotMarketPricesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findSpotMarketPrices",
 		Method:             "GET",
 		PathPattern:        "/market/spot/prices",
@@ -57,7 +59,12 @@ func (a *Client) FindSpotMarketPrices(params *FindSpotMarketPricesParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) FindSpotMarketPrices(params *FindSpotMarketPricesParams, authIn
 
 *Note: In the `200` response, the property `datapoints` contains arrays of `[float, integer]`.*
 */
-func (a *Client) FindSpotMarketPricesHistory(params *FindSpotMarketPricesHistoryParams, authInfo runtime.ClientAuthInfoWriter) (*FindSpotMarketPricesHistoryOK, error) {
+func (a *Client) FindSpotMarketPricesHistory(params *FindSpotMarketPricesHistoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSpotMarketPricesHistoryOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindSpotMarketPricesHistoryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findSpotMarketPricesHistory",
 		Method:             "GET",
 		PathPattern:        "/market/spot/prices/history",
@@ -96,7 +102,12 @@ func (a *Client) FindSpotMarketPricesHistory(params *FindSpotMarketPricesHistory
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/memberships/memberships_client.go
+++ b/client/memberships/memberships_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteMembership(params *DeleteMembershipParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteMembershipNoContent, error)
+	DeleteMembership(params *DeleteMembershipParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteMembershipNoContent, error)
 
-	FindMembershipByID(params *FindMembershipByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindMembershipByIDOK, error)
+	FindMembershipByID(params *FindMembershipByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindMembershipByIDOK, error)
 
-	UpdateMembership(params *UpdateMembershipParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateMembershipOK, error)
+	UpdateMembership(params *UpdateMembershipParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateMembershipOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Deletes the membership.
 */
-func (a *Client) DeleteMembership(params *DeleteMembershipParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteMembershipNoContent, error) {
+func (a *Client) DeleteMembership(params *DeleteMembershipParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteMembershipNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteMembershipParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteMembership",
 		Method:             "DELETE",
 		PathPattern:        "/memberships/{id}",
@@ -59,7 +61,12 @@ func (a *Client) DeleteMembership(params *DeleteMembershipParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) DeleteMembership(params *DeleteMembershipParams, authInfo runti
 
   Returns a single membership.
 */
-func (a *Client) FindMembershipByID(params *FindMembershipByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindMembershipByIDOK, error) {
+func (a *Client) FindMembershipByID(params *FindMembershipByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindMembershipByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindMembershipByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findMembershipById",
 		Method:             "GET",
 		PathPattern:        "/memberships/{id}",
@@ -96,7 +102,12 @@ func (a *Client) FindMembershipByID(params *FindMembershipByIDParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) FindMembershipByID(params *FindMembershipByIDParams, authInfo r
 
   Updates the membership.
 */
-func (a *Client) UpdateMembership(params *UpdateMembershipParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateMembershipOK, error) {
+func (a *Client) UpdateMembership(params *UpdateMembershipParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateMembershipOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateMembershipParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateMembership",
 		Method:             "PUT",
 		PathPattern:        "/memberships/{id}",
@@ -133,7 +143,12 @@ func (a *Client) UpdateMembership(params *UpdateMembershipParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/operating_system_versions/operating_system_versions_client.go
+++ b/client/operating_system_versions/operating_system_versions_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindOperatingSystemVersion(params *FindOperatingSystemVersionParams, authInfo runtime.ClientAuthInfoWriter) (*FindOperatingSystemVersionOK, error)
+	FindOperatingSystemVersion(params *FindOperatingSystemVersionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOperatingSystemVersionOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -37,13 +40,12 @@ type ClientService interface {
 
   Provides a listing of available operating system versions.
 */
-func (a *Client) FindOperatingSystemVersion(params *FindOperatingSystemVersionParams, authInfo runtime.ClientAuthInfoWriter) (*FindOperatingSystemVersionOK, error) {
+func (a *Client) FindOperatingSystemVersion(params *FindOperatingSystemVersionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOperatingSystemVersionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOperatingSystemVersionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOperatingSystemVersion",
 		Method:             "GET",
 		PathPattern:        "/operating-system-versions",
@@ -55,7 +57,12 @@ func (a *Client) FindOperatingSystemVersion(params *FindOperatingSystemVersionPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/operating_systems/operating_systems_client.go
+++ b/client/operating_systems/operating_systems_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindOperatingSystems(params *FindOperatingSystemsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOperatingSystemsOK, error)
+	FindOperatingSystems(params *FindOperatingSystemsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOperatingSystemsOK, error)
 
-	FindOperatingSystemsByOrganization(params *FindOperatingSystemsByOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*FindOperatingSystemsByOrganizationOK, error)
+	FindOperatingSystemsByOrganization(params *FindOperatingSystemsByOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOperatingSystemsByOrganizationOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Provides a listing of available operating systems to provision your new device with.
 */
-func (a *Client) FindOperatingSystems(params *FindOperatingSystemsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOperatingSystemsOK, error) {
+func (a *Client) FindOperatingSystems(params *FindOperatingSystemsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOperatingSystemsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOperatingSystemsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOperatingSystems",
 		Method:             "GET",
 		PathPattern:        "/operating-systems",
@@ -57,7 +59,12 @@ func (a *Client) FindOperatingSystems(params *FindOperatingSystemsParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) FindOperatingSystems(params *FindOperatingSystemsParams, authIn
 
   Returns a listing of available operating systems for the given organization
 */
-func (a *Client) FindOperatingSystemsByOrganization(params *FindOperatingSystemsByOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*FindOperatingSystemsByOrganizationOK, error) {
+func (a *Client) FindOperatingSystemsByOrganization(params *FindOperatingSystemsByOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOperatingSystemsByOrganizationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOperatingSystemsByOrganizationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOperatingSystemsByOrganization",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/operating-systems",
@@ -94,7 +100,12 @@ func (a *Client) FindOperatingSystemsByOrganization(params *FindOperatingSystems
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/organizations/organizations_client.go
+++ b/client/organizations/organizations_client.go
@@ -25,31 +25,34 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateOrganization(params *CreateOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationCreated, error)
+	CreateOrganization(params *CreateOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationCreated, error)
 
-	CreateOrganizationProject(params *CreateOrganizationProjectParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationProjectCreated, error)
+	CreateOrganizationProject(params *CreateOrganizationProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationProjectCreated, error)
 
-	CreatePaymentMethod(params *CreatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter) (*CreatePaymentMethodCreated, error)
+	CreatePaymentMethod(params *CreatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreatePaymentMethodCreated, error)
 
-	DeleteOrganization(params *DeleteOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteOrganizationNoContent, error)
+	DeleteOrganization(params *DeleteOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteOrganizationNoContent, error)
 
-	FindOrganizationByID(params *FindOrganizationByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationByIDOK, error)
+	FindOrganizationByID(params *FindOrganizationByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationByIDOK, error)
 
-	FindOrganizationCustomdata(params *FindOrganizationCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationCustomdataOK, error)
+	FindOrganizationCustomdata(params *FindOrganizationCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationCustomdataOK, error)
 
-	FindOrganizationDevices(params *FindOrganizationDevicesParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationDevicesOK, error)
+	FindOrganizationDevices(params *FindOrganizationDevicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationDevicesOK, error)
 
-	FindOrganizationPaymentMethods(params *FindOrganizationPaymentMethodsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationPaymentMethodsOK, error)
+	FindOrganizationPaymentMethods(params *FindOrganizationPaymentMethodsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationPaymentMethodsOK, error)
 
-	FindOrganizationProjects(params *FindOrganizationProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationProjectsOK, error)
+	FindOrganizationProjects(params *FindOrganizationProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationProjectsOK, error)
 
-	FindOrganizationTransfers(params *FindOrganizationTransfersParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationTransfersOK, error)
+	FindOrganizationTransfers(params *FindOrganizationTransfersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationTransfersOK, error)
 
-	FindOrganizations(params *FindOrganizationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationsOK, error)
+	FindOrganizations(params *FindOrganizationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationsOK, error)
 
-	UpdateOrganization(params *UpdateOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateOrganizationOK, error)
+	UpdateOrganization(params *UpdateOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateOrganizationOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -59,13 +62,12 @@ type ClientService interface {
 
   Creates an organization.
 */
-func (a *Client) CreateOrganization(params *CreateOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationCreated, error) {
+func (a *Client) CreateOrganization(params *CreateOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateOrganizationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createOrganization",
 		Method:             "POST",
 		PathPattern:        "/organizations",
@@ -77,7 +79,12 @@ func (a *Client) CreateOrganization(params *CreateOrganizationParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -96,13 +103,12 @@ func (a *Client) CreateOrganization(params *CreateOrganizationParams, authInfo r
 
   Creates a new project for the organization
 */
-func (a *Client) CreateOrganizationProject(params *CreateOrganizationProjectParams, authInfo runtime.ClientAuthInfoWriter) (*CreateOrganizationProjectCreated, error) {
+func (a *Client) CreateOrganizationProject(params *CreateOrganizationProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateOrganizationProjectCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateOrganizationProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createOrganizationProject",
 		Method:             "POST",
 		PathPattern:        "/organizations/{id}/projects",
@@ -114,7 +120,12 @@ func (a *Client) CreateOrganizationProject(params *CreateOrganizationProjectPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -133,13 +144,12 @@ func (a *Client) CreateOrganizationProject(params *CreateOrganizationProjectPara
 
   Creates a payment method.
 */
-func (a *Client) CreatePaymentMethod(params *CreatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter) (*CreatePaymentMethodCreated, error) {
+func (a *Client) CreatePaymentMethod(params *CreatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreatePaymentMethodCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreatePaymentMethodParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createPaymentMethod",
 		Method:             "POST",
 		PathPattern:        "/organizations/{id}/payment-methods",
@@ -151,7 +161,12 @@ func (a *Client) CreatePaymentMethod(params *CreatePaymentMethodParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -170,13 +185,12 @@ func (a *Client) CreatePaymentMethod(params *CreatePaymentMethodParams, authInfo
 
   Deletes the organization.
 */
-func (a *Client) DeleteOrganization(params *DeleteOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteOrganizationNoContent, error) {
+func (a *Client) DeleteOrganization(params *DeleteOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteOrganizationNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteOrganizationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteOrganization",
 		Method:             "DELETE",
 		PathPattern:        "/organizations/{id}",
@@ -188,7 +202,12 @@ func (a *Client) DeleteOrganization(params *DeleteOrganizationParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -207,13 +226,12 @@ func (a *Client) DeleteOrganization(params *DeleteOrganizationParams, authInfo r
 
   Returns a single organization's details, if the user is authorized to view it.
 */
-func (a *Client) FindOrganizationByID(params *FindOrganizationByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationByIDOK, error) {
+func (a *Client) FindOrganizationByID(params *FindOrganizationByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationById",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}",
@@ -225,7 +243,12 @@ func (a *Client) FindOrganizationByID(params *FindOrganizationByIDParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -244,13 +267,12 @@ func (a *Client) FindOrganizationByID(params *FindOrganizationByIDParams, authIn
 
   Provides the custom metadata stored for this organization in json format
 */
-func (a *Client) FindOrganizationCustomdata(params *FindOrganizationCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationCustomdataOK, error) {
+func (a *Client) FindOrganizationCustomdata(params *FindOrganizationCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationCustomdata",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/customdata",
@@ -262,7 +284,12 @@ func (a *Client) FindOrganizationCustomdata(params *FindOrganizationCustomdataPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -281,13 +308,12 @@ func (a *Client) FindOrganizationCustomdata(params *FindOrganizationCustomdataPa
 
   Provides a collection of devices for a given organization.
 */
-func (a *Client) FindOrganizationDevices(params *FindOrganizationDevicesParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationDevicesOK, error) {
+func (a *Client) FindOrganizationDevices(params *FindOrganizationDevicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationDevicesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationDevicesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationDevices",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/devices",
@@ -299,7 +325,12 @@ func (a *Client) FindOrganizationDevices(params *FindOrganizationDevicesParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -318,13 +349,12 @@ func (a *Client) FindOrganizationDevices(params *FindOrganizationDevicesParams, 
 
   Returns all payment methods of an organization.
 */
-func (a *Client) FindOrganizationPaymentMethods(params *FindOrganizationPaymentMethodsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationPaymentMethodsOK, error) {
+func (a *Client) FindOrganizationPaymentMethods(params *FindOrganizationPaymentMethodsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationPaymentMethodsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationPaymentMethodsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationPaymentMethods",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/payment-methods",
@@ -336,7 +366,12 @@ func (a *Client) FindOrganizationPaymentMethods(params *FindOrganizationPaymentM
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -355,13 +390,12 @@ func (a *Client) FindOrganizationPaymentMethods(params *FindOrganizationPaymentM
 
   Returns a collection of projects that belong to the organization.
 */
-func (a *Client) FindOrganizationProjects(params *FindOrganizationProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationProjectsOK, error) {
+func (a *Client) FindOrganizationProjects(params *FindOrganizationProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationProjectsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationProjectsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationProjects",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/projects",
@@ -373,7 +407,12 @@ func (a *Client) FindOrganizationProjects(params *FindOrganizationProjectsParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -392,13 +431,12 @@ func (a *Client) FindOrganizationProjects(params *FindOrganizationProjectsParams
 
   Provides a collection of project transfer requests from or to the organization.
 */
-func (a *Client) FindOrganizationTransfers(params *FindOrganizationTransfersParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationTransfersOK, error) {
+func (a *Client) FindOrganizationTransfers(params *FindOrganizationTransfersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationTransfersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationTransfersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizationTransfers",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/transfers",
@@ -410,7 +448,12 @@ func (a *Client) FindOrganizationTransfers(params *FindOrganizationTransfersPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -429,13 +472,12 @@ func (a *Client) FindOrganizationTransfers(params *FindOrganizationTransfersPara
 
   Returns a list of organizations that are accessible to the current user.
 */
-func (a *Client) FindOrganizations(params *FindOrganizationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindOrganizationsOK, error) {
+func (a *Client) FindOrganizations(params *FindOrganizationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindOrganizationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindOrganizationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findOrganizations",
 		Method:             "GET",
 		PathPattern:        "/organizations",
@@ -447,7 +489,12 @@ func (a *Client) FindOrganizations(params *FindOrganizationsParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -466,13 +513,12 @@ func (a *Client) FindOrganizations(params *FindOrganizationsParams, authInfo run
 
   Updates the organization.
 */
-func (a *Client) UpdateOrganization(params *UpdateOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateOrganizationOK, error) {
+func (a *Client) UpdateOrganization(params *UpdateOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateOrganizationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateOrganizationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateOrganization",
 		Method:             "PUT",
 		PathPattern:        "/organizations/{id}",
@@ -484,7 +530,12 @@ func (a *Client) UpdateOrganization(params *UpdateOrganizationParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/otps/otps_client.go
+++ b/client/otps/otps_client.go
@@ -25,15 +25,18 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindEnsureOtp(params *FindEnsureOtpParams, authInfo runtime.ClientAuthInfoWriter) (*FindEnsureOtpNoContent, error)
+	FindEnsureOtp(params *FindEnsureOtpParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEnsureOtpNoContent, error)
 
-	FindRecoveryCodes(params *FindRecoveryCodesParams, authInfo runtime.ClientAuthInfoWriter) (*FindRecoveryCodesOK, error)
+	FindRecoveryCodes(params *FindRecoveryCodesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindRecoveryCodesOK, error)
 
-	ReceiveCodes(params *ReceiveCodesParams, authInfo runtime.ClientAuthInfoWriter) (*ReceiveCodesNoContent, error)
+	ReceiveCodes(params *ReceiveCodesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ReceiveCodesNoContent, error)
 
-	RegenerateCodes(params *RegenerateCodesParams, authInfo runtime.ClientAuthInfoWriter) (*RegenerateCodesOK, error)
+	RegenerateCodes(params *RegenerateCodesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RegenerateCodesOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,13 +46,12 @@ type ClientService interface {
 
   It verifies the user once a valid OTP is provided. It gives back a session token, essentially logging in the user.
 */
-func (a *Client) FindEnsureOtp(params *FindEnsureOtpParams, authInfo runtime.ClientAuthInfoWriter) (*FindEnsureOtpNoContent, error) {
+func (a *Client) FindEnsureOtp(params *FindEnsureOtpParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindEnsureOtpNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindEnsureOtpParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findEnsureOtp",
 		Method:             "POST",
 		PathPattern:        "/user/otp/verify/{otp}",
@@ -61,7 +63,12 @@ func (a *Client) FindEnsureOtp(params *FindEnsureOtpParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +87,12 @@ func (a *Client) FindEnsureOtp(params *FindEnsureOtpParams, authInfo runtime.Cli
 
   Returns my recovery codes.
 */
-func (a *Client) FindRecoveryCodes(params *FindRecoveryCodesParams, authInfo runtime.ClientAuthInfoWriter) (*FindRecoveryCodesOK, error) {
+func (a *Client) FindRecoveryCodes(params *FindRecoveryCodesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindRecoveryCodesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindRecoveryCodesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findRecoveryCodes",
 		Method:             "GET",
 		PathPattern:        "/user/otp/recovery-codes",
@@ -98,7 +104,12 @@ func (a *Client) FindRecoveryCodes(params *FindRecoveryCodesParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +128,12 @@ func (a *Client) FindRecoveryCodes(params *FindRecoveryCodesParams, authInfo run
 
   Sends an OTP to the user's mobile phone.
 */
-func (a *Client) ReceiveCodes(params *ReceiveCodesParams, authInfo runtime.ClientAuthInfoWriter) (*ReceiveCodesNoContent, error) {
+func (a *Client) ReceiveCodes(params *ReceiveCodesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ReceiveCodesNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewReceiveCodesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "receiveCodes",
 		Method:             "POST",
 		PathPattern:        "/user/otp/sms/receive",
@@ -135,7 +145,12 @@ func (a *Client) ReceiveCodes(params *ReceiveCodesParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -154,13 +169,12 @@ func (a *Client) ReceiveCodes(params *ReceiveCodesParams, authInfo runtime.Clien
 
   Generate a new set of recovery codes.
 */
-func (a *Client) RegenerateCodes(params *RegenerateCodesParams, authInfo runtime.ClientAuthInfoWriter) (*RegenerateCodesOK, error) {
+func (a *Client) RegenerateCodes(params *RegenerateCodesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RegenerateCodesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRegenerateCodesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "regenerateCodes",
 		Method:             "POST",
 		PathPattern:        "/user/otp/recovery-codes",
@@ -172,7 +186,12 @@ func (a *Client) RegenerateCodes(params *RegenerateCodesParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/password_reset_tokens/password_reset_tokens_client.go
+++ b/client/password_reset_tokens/password_reset_tokens_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreatePasswordResetToken(params *CreatePasswordResetTokenParams, authInfo runtime.ClientAuthInfoWriter) (*CreatePasswordResetTokenCreated, error)
+	CreatePasswordResetToken(params *CreatePasswordResetTokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreatePasswordResetTokenCreated, error)
 
-	ResetPassword(params *ResetPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*ResetPasswordCreated, error)
+	ResetPassword(params *ResetPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ResetPasswordCreated, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Creates a password reset token
 */
-func (a *Client) CreatePasswordResetToken(params *CreatePasswordResetTokenParams, authInfo runtime.ClientAuthInfoWriter) (*CreatePasswordResetTokenCreated, error) {
+func (a *Client) CreatePasswordResetToken(params *CreatePasswordResetTokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreatePasswordResetTokenCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreatePasswordResetTokenParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createPasswordResetToken",
 		Method:             "POST",
 		PathPattern:        "/reset-password",
@@ -57,7 +59,12 @@ func (a *Client) CreatePasswordResetToken(params *CreatePasswordResetTokenParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) CreatePasswordResetToken(params *CreatePasswordResetTokenParams
 
   Resets current user password.
 */
-func (a *Client) ResetPassword(params *ResetPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*ResetPasswordCreated, error) {
+func (a *Client) ResetPassword(params *ResetPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ResetPasswordCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewResetPasswordParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "resetPassword",
 		Method:             "DELETE",
 		PathPattern:        "/reset-password",
@@ -94,7 +100,12 @@ func (a *Client) ResetPassword(params *ResetPasswordParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/payment_methods/payment_methods_client.go
+++ b/client/payment_methods/payment_methods_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeletePaymentMethod(params *DeletePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter) (*DeletePaymentMethodNoContent, error)
+	DeletePaymentMethod(params *DeletePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeletePaymentMethodNoContent, error)
 
-	FindPaymentMethodByID(params *FindPaymentMethodByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindPaymentMethodByIDOK, error)
+	FindPaymentMethodByID(params *FindPaymentMethodByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPaymentMethodByIDOK, error)
 
-	UpdatePaymentMethod(params *UpdatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter) (*UpdatePaymentMethodOK, error)
+	UpdatePaymentMethod(params *UpdatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdatePaymentMethodOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Deletes the payment method.
 */
-func (a *Client) DeletePaymentMethod(params *DeletePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter) (*DeletePaymentMethodNoContent, error) {
+func (a *Client) DeletePaymentMethod(params *DeletePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeletePaymentMethodNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeletePaymentMethodParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deletePaymentMethod",
 		Method:             "DELETE",
 		PathPattern:        "/payment-methods/{id}",
@@ -59,7 +61,12 @@ func (a *Client) DeletePaymentMethod(params *DeletePaymentMethodParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) DeletePaymentMethod(params *DeletePaymentMethodParams, authInfo
 
   Returns a payment method
 */
-func (a *Client) FindPaymentMethodByID(params *FindPaymentMethodByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindPaymentMethodByIDOK, error) {
+func (a *Client) FindPaymentMethodByID(params *FindPaymentMethodByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPaymentMethodByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindPaymentMethodByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findPaymentMethodById",
 		Method:             "GET",
 		PathPattern:        "/payment-methods/{id}",
@@ -96,7 +102,12 @@ func (a *Client) FindPaymentMethodByID(params *FindPaymentMethodByIDParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) FindPaymentMethodByID(params *FindPaymentMethodByIDParams, auth
 
   Updates the payment method.
 */
-func (a *Client) UpdatePaymentMethod(params *UpdatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter) (*UpdatePaymentMethodOK, error) {
+func (a *Client) UpdatePaymentMethod(params *UpdatePaymentMethodParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdatePaymentMethodOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdatePaymentMethodParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updatePaymentMethod",
 		Method:             "PUT",
 		PathPattern:        "/payment-methods/{id}",
@@ -133,7 +143,12 @@ func (a *Client) UpdatePaymentMethod(params *UpdatePaymentMethodParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/plans/plans_client.go
+++ b/client/plans/plans_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindPlans(params *FindPlansParams, authInfo runtime.ClientAuthInfoWriter) (*FindPlansOK, error)
+	FindPlans(params *FindPlansParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPlansOK, error)
 
-	FindPlansByOrganization(params *FindPlansByOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*FindPlansByOrganizationOK, error)
+	FindPlansByOrganization(params *FindPlansByOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPlansByOrganizationOK, error)
 
-	FindPlansByProject(params *FindPlansByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindPlansByProjectOK, error)
+	FindPlansByProject(params *FindPlansByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPlansByProjectOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Provides a listing of available plans to provision your device on.
 */
-func (a *Client) FindPlans(params *FindPlansParams, authInfo runtime.ClientAuthInfoWriter) (*FindPlansOK, error) {
+func (a *Client) FindPlans(params *FindPlansParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPlansOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindPlansParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findPlans",
 		Method:             "GET",
 		PathPattern:        "/plans",
@@ -59,7 +61,12 @@ func (a *Client) FindPlans(params *FindPlansParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) FindPlans(params *FindPlansParams, authInfo runtime.ClientAuthI
 
   Returns a listing of available plans for the given organization
 */
-func (a *Client) FindPlansByOrganization(params *FindPlansByOrganizationParams, authInfo runtime.ClientAuthInfoWriter) (*FindPlansByOrganizationOK, error) {
+func (a *Client) FindPlansByOrganization(params *FindPlansByOrganizationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPlansByOrganizationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindPlansByOrganizationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findPlansByOrganization",
 		Method:             "GET",
 		PathPattern:        "/organizations/{id}/plans",
@@ -96,7 +102,12 @@ func (a *Client) FindPlansByOrganization(params *FindPlansByOrganizationParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) FindPlansByOrganization(params *FindPlansByOrganizationParams, 
 
   Returns a listing of available plans for the given project
 */
-func (a *Client) FindPlansByProject(params *FindPlansByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindPlansByProjectOK, error) {
+func (a *Client) FindPlansByProject(params *FindPlansByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPlansByProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindPlansByProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findPlansByProject",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/plans",
@@ -133,7 +143,12 @@ func (a *Client) FindPlansByProject(params *FindPlansByProjectParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/ports/ports_client.go
+++ b/client/ports/ports_client.go
@@ -25,25 +25,28 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AssignNativeVLAN(params *AssignNativeVLANParams, authInfo runtime.ClientAuthInfoWriter) (*AssignNativeVLANOK, error)
+	AssignNativeVLAN(params *AssignNativeVLANParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AssignNativeVLANOK, error)
 
-	AssignPort(params *AssignPortParams, authInfo runtime.ClientAuthInfoWriter) (*AssignPortOK, error)
+	AssignPort(params *AssignPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AssignPortOK, error)
 
-	BondPort(params *BondPortParams, authInfo runtime.ClientAuthInfoWriter) (*BondPortOK, error)
+	BondPort(params *BondPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*BondPortOK, error)
 
-	ConvertLayer2(params *ConvertLayer2Params, authInfo runtime.ClientAuthInfoWriter) (*ConvertLayer2OK, error)
+	ConvertLayer2(params *ConvertLayer2Params, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ConvertLayer2OK, error)
 
-	ConvertLayer3(params *ConvertLayer3Params, authInfo runtime.ClientAuthInfoWriter) (*ConvertLayer3OK, error)
+	ConvertLayer3(params *ConvertLayer3Params, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ConvertLayer3OK, error)
 
-	DeleteNativeVLAN(params *DeleteNativeVLANParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteNativeVLANOK, error)
+	DeleteNativeVLAN(params *DeleteNativeVLANParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNativeVLANOK, error)
 
-	DisbondPort(params *DisbondPortParams, authInfo runtime.ClientAuthInfoWriter) (*DisbondPortOK, error)
+	DisbondPort(params *DisbondPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DisbondPortOK, error)
 
-	FindPortByID(params *FindPortByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindPortByIDOK, error)
+	FindPortByID(params *FindPortByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPortByIDOK, error)
 
-	UnassignPort(params *UnassignPortParams, authInfo runtime.ClientAuthInfoWriter) (*UnassignPortOK, error)
+	UnassignPort(params *UnassignPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UnassignPortOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -53,13 +56,12 @@ type ClientService interface {
 
   Assigns a virtual network to this port as a "native VLAN"
 */
-func (a *Client) AssignNativeVLAN(params *AssignNativeVLANParams, authInfo runtime.ClientAuthInfoWriter) (*AssignNativeVLANOK, error) {
+func (a *Client) AssignNativeVLAN(params *AssignNativeVLANParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AssignNativeVLANOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAssignNativeVLANParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "assignNativeVlan",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/native-vlan",
@@ -71,7 +73,12 @@ func (a *Client) AssignNativeVLAN(params *AssignNativeVLANParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -90,13 +97,12 @@ func (a *Client) AssignNativeVLAN(params *AssignNativeVLANParams, authInfo runti
 
   Assign a port for a hardware to virtual network.
 */
-func (a *Client) AssignPort(params *AssignPortParams, authInfo runtime.ClientAuthInfoWriter) (*AssignPortOK, error) {
+func (a *Client) AssignPort(params *AssignPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AssignPortOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAssignPortParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "assignPort",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/assign",
@@ -108,7 +114,12 @@ func (a *Client) AssignPort(params *AssignPortParams, authInfo runtime.ClientAut
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +138,12 @@ func (a *Client) AssignPort(params *AssignPortParams, authInfo runtime.ClientAut
 
   Enabling bonding for one or all ports
 */
-func (a *Client) BondPort(params *BondPortParams, authInfo runtime.ClientAuthInfoWriter) (*BondPortOK, error) {
+func (a *Client) BondPort(params *BondPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*BondPortOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewBondPortParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "bondPort",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/bond",
@@ -145,7 +155,12 @@ func (a *Client) BondPort(params *BondPortParams, authInfo runtime.ClientAuthInf
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -164,13 +179,12 @@ func (a *Client) BondPort(params *BondPortParams, authInfo runtime.ClientAuthInf
 
   Converts a bond port to Layer 2. IP assignments of the port will be removed.
 */
-func (a *Client) ConvertLayer2(params *ConvertLayer2Params, authInfo runtime.ClientAuthInfoWriter) (*ConvertLayer2OK, error) {
+func (a *Client) ConvertLayer2(params *ConvertLayer2Params, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ConvertLayer2OK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewConvertLayer2Params()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "convertLayer2",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/convert/layer-2",
@@ -182,7 +196,12 @@ func (a *Client) ConvertLayer2(params *ConvertLayer2Params, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -201,13 +220,12 @@ func (a *Client) ConvertLayer2(params *ConvertLayer2Params, authInfo runtime.Cli
 
   Converts a bond port to Layer 3. VLANs must first be unassigned.
 */
-func (a *Client) ConvertLayer3(params *ConvertLayer3Params, authInfo runtime.ClientAuthInfoWriter) (*ConvertLayer3OK, error) {
+func (a *Client) ConvertLayer3(params *ConvertLayer3Params, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ConvertLayer3OK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewConvertLayer3Params()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "convertLayer3",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/convert/layer-3",
@@ -219,7 +237,12 @@ func (a *Client) ConvertLayer3(params *ConvertLayer3Params, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +261,12 @@ func (a *Client) ConvertLayer3(params *ConvertLayer3Params, authInfo runtime.Cli
 
   Removes the native VLAN from this port
 */
-func (a *Client) DeleteNativeVLAN(params *DeleteNativeVLANParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteNativeVLANOK, error) {
+func (a *Client) DeleteNativeVLAN(params *DeleteNativeVLANParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNativeVLANOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteNativeVLANParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteNativeVlan",
 		Method:             "DELETE",
 		PathPattern:        "/ports/{id}/native-vlan",
@@ -256,7 +278,12 @@ func (a *Client) DeleteNativeVLAN(params *DeleteNativeVLANParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -275,13 +302,12 @@ func (a *Client) DeleteNativeVLAN(params *DeleteNativeVLANParams, authInfo runti
 
   Disabling bonding for one or all ports
 */
-func (a *Client) DisbondPort(params *DisbondPortParams, authInfo runtime.ClientAuthInfoWriter) (*DisbondPortOK, error) {
+func (a *Client) DisbondPort(params *DisbondPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DisbondPortOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDisbondPortParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "disbondPort",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/disbond",
@@ -293,7 +319,12 @@ func (a *Client) DisbondPort(params *DisbondPortParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -312,13 +343,12 @@ func (a *Client) DisbondPort(params *DisbondPortParams, authInfo runtime.ClientA
 
   Returns a port
 */
-func (a *Client) FindPortByID(params *FindPortByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindPortByIDOK, error) {
+func (a *Client) FindPortByID(params *FindPortByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindPortByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindPortByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findPortById",
 		Method:             "GET",
 		PathPattern:        "/ports/{id}",
@@ -330,7 +360,12 @@ func (a *Client) FindPortByID(params *FindPortByIDParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -349,13 +384,12 @@ func (a *Client) FindPortByID(params *FindPortByIDParams, authInfo runtime.Clien
 
   Unassign a port for a hardware.
 */
-func (a *Client) UnassignPort(params *UnassignPortParams, authInfo runtime.ClientAuthInfoWriter) (*UnassignPortOK, error) {
+func (a *Client) UnassignPort(params *UnassignPortParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UnassignPortOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUnassignPortParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "unassignPort",
 		Method:             "POST",
 		PathPattern:        "/ports/{id}/unassign",
@@ -367,7 +401,12 @@ func (a *Client) UnassignPort(params *UnassignPortParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/projects/projects_client.go
+++ b/client/projects/projects_client.go
@@ -25,61 +25,64 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateDevice(params *CreateDeviceParams, authInfo runtime.ClientAuthInfoWriter) (*CreateDeviceCreated, error)
+	CreateDevice(params *CreateDeviceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateDeviceCreated, error)
 
-	CreateLicense(params *CreateLicenseParams, authInfo runtime.ClientAuthInfoWriter) (*CreateLicenseCreated, error)
+	CreateLicense(params *CreateLicenseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateLicenseCreated, error)
 
-	CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectCreated, error)
+	CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectCreated, error)
 
-	CreateProjectSSHKey(params *CreateProjectSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectSSHKeyCreated, error)
+	CreateProjectSSHKey(params *CreateProjectSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectSSHKeyCreated, error)
 
-	CreateSpotMarketRequest(params *CreateSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter) (*CreateSpotMarketRequestCreated, error)
+	CreateSpotMarketRequest(params *CreateSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateSpotMarketRequestCreated, error)
 
-	CreateTransferRequest(params *CreateTransferRequestParams, authInfo runtime.ClientAuthInfoWriter) (*CreateTransferRequestCreated, error)
+	CreateTransferRequest(params *CreateTransferRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateTransferRequestCreated, error)
 
-	CreateVirtualNetwork(params *CreateVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVirtualNetworkCreated, error)
+	CreateVirtualNetwork(params *CreateVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVirtualNetworkCreated, error)
 
-	DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectNoContent, error)
+	DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectNoContent, error)
 
-	FindBatchesByProject(params *FindBatchesByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindBatchesByProjectOK, error)
+	FindBatchesByProject(params *FindBatchesByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBatchesByProjectOK, error)
 
-	FindBGPConfigByProject(params *FindBGPConfigByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindBGPConfigByProjectOK, error)
+	FindBGPConfigByProject(params *FindBGPConfigByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBGPConfigByProjectOK, error)
 
-	FindDeviceSSHKeys(params *FindDeviceSSHKeysParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceSSHKeysOK, error)
+	FindDeviceSSHKeys(params *FindDeviceSSHKeysParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceSSHKeysOK, error)
 
-	FindIPReservationCustomdata(params *FindIPReservationCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPReservationCustomdataOK, error)
+	FindIPReservationCustomdata(params *FindIPReservationCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPReservationCustomdataOK, error)
 
-	FindIPReservations(params *FindIPReservationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPReservationsOK, error)
+	FindIPReservations(params *FindIPReservationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPReservationsOK, error)
 
-	FindProjectBGPSessions(params *FindProjectBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectBGPSessionsOK, error)
+	FindProjectBGPSessions(params *FindProjectBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectBGPSessionsOK, error)
 
-	FindProjectByID(params *FindProjectByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectByIDOK, error)
+	FindProjectByID(params *FindProjectByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectByIDOK, error)
 
-	FindProjectCustomdata(params *FindProjectCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectCustomdataOK, error)
+	FindProjectCustomdata(params *FindProjectCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectCustomdataOK, error)
 
-	FindProjectDevices(params *FindProjectDevicesParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectDevicesOK, error)
+	FindProjectDevices(params *FindProjectDevicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectDevicesOK, error)
 
-	FindProjectHardwareReservations(params *FindProjectHardwareReservationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectHardwareReservationsOK, error)
+	FindProjectHardwareReservations(params *FindProjectHardwareReservationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectHardwareReservationsOK, error)
 
-	FindProjectLicenses(params *FindProjectLicensesParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectLicensesOK, error)
+	FindProjectLicenses(params *FindProjectLicensesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectLicensesOK, error)
 
-	FindProjectMemberships(params *FindProjectMembershipsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectMembershipsOK, error)
+	FindProjectMemberships(params *FindProjectMembershipsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectMembershipsOK, error)
 
-	FindProjectSSHKeys(params *FindProjectSSHKeysParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectSSHKeysOK, error)
+	FindProjectSSHKeys(params *FindProjectSSHKeysParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectSSHKeysOK, error)
 
-	FindProjects(params *FindProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectsOK, error)
+	FindProjects(params *FindProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectsOK, error)
 
-	FindVirtualNetworks(params *FindVirtualNetworksParams, authInfo runtime.ClientAuthInfoWriter) (*FindVirtualNetworksOK, error)
+	FindVirtualNetworks(params *FindVirtualNetworksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVirtualNetworksOK, error)
 
-	ListSpotMarketRequests(params *ListSpotMarketRequestsParams, authInfo runtime.ClientAuthInfoWriter) (*ListSpotMarketRequestsOK, error)
+	ListSpotMarketRequests(params *ListSpotMarketRequestsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListSpotMarketRequestsOK, error)
 
-	RequestBGPConfig(params *RequestBGPConfigParams, authInfo runtime.ClientAuthInfoWriter) (*RequestBGPConfigNoContent, error)
+	RequestBGPConfig(params *RequestBGPConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RequestBGPConfigNoContent, error)
 
-	RequestIPReservation(params *RequestIPReservationParams, authInfo runtime.ClientAuthInfoWriter) (*RequestIPReservationCreated, error)
+	RequestIPReservation(params *RequestIPReservationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RequestIPReservationCreated, error)
 
-	UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateProjectOK, error)
+	UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateProjectOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -120,13 +123,12 @@ For example, `{ "ip_addresses": [..., {"address_family": 4, "public": true, "ip_
 To access a server without public IPs, you can use our Out-of-Band console access (SOS) or use another server with public IPs as a proxy.
 
 */
-func (a *Client) CreateDevice(params *CreateDeviceParams, authInfo runtime.ClientAuthInfoWriter) (*CreateDeviceCreated, error) {
+func (a *Client) CreateDevice(params *CreateDeviceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateDeviceCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateDeviceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createDevice",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/devices",
@@ -138,7 +140,12 @@ func (a *Client) CreateDevice(params *CreateDeviceParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -157,13 +164,12 @@ func (a *Client) CreateDevice(params *CreateDeviceParams, authInfo runtime.Clien
 
   Creates a new license for the given project
 */
-func (a *Client) CreateLicense(params *CreateLicenseParams, authInfo runtime.ClientAuthInfoWriter) (*CreateLicenseCreated, error) {
+func (a *Client) CreateLicense(params *CreateLicenseParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateLicenseCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateLicenseParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createLicense",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/licenses",
@@ -175,7 +181,12 @@ func (a *Client) CreateLicense(params *CreateLicenseParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -194,13 +205,12 @@ func (a *Client) CreateLicense(params *CreateLicenseParams, authInfo runtime.Cli
 
   Creates a new project for the user default organization. If the user don't have an organization, a new one will be created.
 */
-func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectCreated, error) {
+func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createProject",
 		Method:             "POST",
 		PathPattern:        "/projects",
@@ -212,7 +222,12 @@ func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -231,13 +246,12 @@ func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.Cli
 
   Creates a ssh key.
 */
-func (a *Client) CreateProjectSSHKey(params *CreateProjectSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectSSHKeyCreated, error) {
+func (a *Client) CreateProjectSSHKey(params *CreateProjectSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectSSHKeyCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateProjectSSHKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createProjectSSHKey",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/ssh-keys",
@@ -249,7 +263,12 @@ func (a *Client) CreateProjectSSHKey(params *CreateProjectSSHKeyParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -276,13 +295,12 @@ The request will fail if there are no available servers matching your criteria. 
 
 The request will not fail if we have no servers with that feature in our inventory.
 */
-func (a *Client) CreateSpotMarketRequest(params *CreateSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter) (*CreateSpotMarketRequestCreated, error) {
+func (a *Client) CreateSpotMarketRequest(params *CreateSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateSpotMarketRequestCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateSpotMarketRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createSpotMarketRequest",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/spot-market-requests",
@@ -294,7 +312,12 @@ func (a *Client) CreateSpotMarketRequest(params *CreateSpotMarketRequestParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -313,13 +336,12 @@ func (a *Client) CreateSpotMarketRequest(params *CreateSpotMarketRequestParams, 
 
   Organization owners can transfer their projects to other organizations.
 */
-func (a *Client) CreateTransferRequest(params *CreateTransferRequestParams, authInfo runtime.ClientAuthInfoWriter) (*CreateTransferRequestCreated, error) {
+func (a *Client) CreateTransferRequest(params *CreateTransferRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateTransferRequestCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateTransferRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createTransferRequest",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/transfers",
@@ -331,7 +353,12 @@ func (a *Client) CreateTransferRequest(params *CreateTransferRequestParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -350,13 +377,12 @@ func (a *Client) CreateTransferRequest(params *CreateTransferRequestParams, auth
 
   Creates an virtual network.
 */
-func (a *Client) CreateVirtualNetwork(params *CreateVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVirtualNetworkCreated, error) {
+func (a *Client) CreateVirtualNetwork(params *CreateVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVirtualNetworkCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateVirtualNetworkParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createVirtualNetwork",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/virtual-networks",
@@ -368,7 +394,12 @@ func (a *Client) CreateVirtualNetwork(params *CreateVirtualNetworkParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -387,13 +418,12 @@ func (a *Client) CreateVirtualNetwork(params *CreateVirtualNetworkParams, authIn
 
   Deletes the project.
 */
-func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectNoContent, error) {
+func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteProject",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{id}",
@@ -405,7 +435,12 @@ func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -424,13 +459,12 @@ func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.Cli
 
   Returns all batches for the given project
 */
-func (a *Client) FindBatchesByProject(params *FindBatchesByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindBatchesByProjectOK, error) {
+func (a *Client) FindBatchesByProject(params *FindBatchesByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBatchesByProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindBatchesByProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findBatchesByProject",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/batches",
@@ -442,7 +476,12 @@ func (a *Client) FindBatchesByProject(params *FindBatchesByProjectParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -461,13 +500,12 @@ func (a *Client) FindBatchesByProject(params *FindBatchesByProjectParams, authIn
 
   Returns a bgp config
 */
-func (a *Client) FindBGPConfigByProject(params *FindBGPConfigByProjectParams, authInfo runtime.ClientAuthInfoWriter) (*FindBGPConfigByProjectOK, error) {
+func (a *Client) FindBGPConfigByProject(params *FindBGPConfigByProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindBGPConfigByProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindBGPConfigByProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findBgpConfigByProject",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/bgp-config",
@@ -479,7 +517,12 @@ func (a *Client) FindBGPConfigByProject(params *FindBGPConfigByProjectParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -498,13 +541,12 @@ func (a *Client) FindBGPConfigByProject(params *FindBGPConfigByProjectParams, au
 
   Returns a collection of the device's ssh keys.
 */
-func (a *Client) FindDeviceSSHKeys(params *FindDeviceSSHKeysParams, authInfo runtime.ClientAuthInfoWriter) (*FindDeviceSSHKeysOK, error) {
+func (a *Client) FindDeviceSSHKeys(params *FindDeviceSSHKeysParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindDeviceSSHKeysOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindDeviceSSHKeysParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findDeviceSSHKeys",
 		Method:             "GET",
 		PathPattern:        "/devices/{id}/ssh-keys",
@@ -516,7 +558,12 @@ func (a *Client) FindDeviceSSHKeys(params *FindDeviceSSHKeysParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -535,13 +582,12 @@ func (a *Client) FindDeviceSSHKeys(params *FindDeviceSSHKeysParams, authInfo run
 
   Provides the custom metadata stored for this IP Reservation in json format
 */
-func (a *Client) FindIPReservationCustomdata(params *FindIPReservationCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPReservationCustomdataOK, error) {
+func (a *Client) FindIPReservationCustomdata(params *FindIPReservationCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPReservationCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPReservationCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPReservationCustomdata",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/ips/{id}/customdata",
@@ -553,7 +599,12 @@ func (a *Client) FindIPReservationCustomdata(params *FindIPReservationCustomdata
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -572,13 +623,12 @@ func (a *Client) FindIPReservationCustomdata(params *FindIPReservationCustomdata
 
   Provides a list of IP resevations for a single project.
 */
-func (a *Client) FindIPReservations(params *FindIPReservationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindIPReservationsOK, error) {
+func (a *Client) FindIPReservations(params *FindIPReservationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindIPReservationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindIPReservationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findIPReservations",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/ips",
@@ -590,7 +640,12 @@ func (a *Client) FindIPReservations(params *FindIPReservationsParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -609,13 +664,12 @@ func (a *Client) FindIPReservations(params *FindIPReservationsParams, authInfo r
 
   Provides a listing of available BGP sessions for the project.
 */
-func (a *Client) FindProjectBGPSessions(params *FindProjectBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectBGPSessionsOK, error) {
+func (a *Client) FindProjectBGPSessions(params *FindProjectBGPSessionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectBGPSessionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectBGPSessionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectBgpSessions",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/bgp/sessions",
@@ -627,7 +681,12 @@ func (a *Client) FindProjectBGPSessions(params *FindProjectBGPSessionsParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -646,13 +705,12 @@ func (a *Client) FindProjectBGPSessions(params *FindProjectBGPSessionsParams, au
 
   Returns a single project if the user has access
 */
-func (a *Client) FindProjectByID(params *FindProjectByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectByIDOK, error) {
+func (a *Client) FindProjectByID(params *FindProjectByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectById",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}",
@@ -664,7 +722,12 @@ func (a *Client) FindProjectByID(params *FindProjectByIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -683,13 +746,12 @@ func (a *Client) FindProjectByID(params *FindProjectByIDParams, authInfo runtime
 
   Provides the custom metadata stored for this project in json format
 */
-func (a *Client) FindProjectCustomdata(params *FindProjectCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectCustomdataOK, error) {
+func (a *Client) FindProjectCustomdata(params *FindProjectCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectCustomdata",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/customdata",
@@ -701,7 +763,12 @@ func (a *Client) FindProjectCustomdata(params *FindProjectCustomdataParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -720,13 +787,12 @@ func (a *Client) FindProjectCustomdata(params *FindProjectCustomdataParams, auth
 
   Provides a collection of devices for a given project.
 */
-func (a *Client) FindProjectDevices(params *FindProjectDevicesParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectDevicesOK, error) {
+func (a *Client) FindProjectDevices(params *FindProjectDevicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectDevicesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectDevicesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectDevices",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/devices",
@@ -738,7 +804,12 @@ func (a *Client) FindProjectDevices(params *FindProjectDevicesParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -757,13 +828,12 @@ func (a *Client) FindProjectDevices(params *FindProjectDevicesParams, authInfo r
 
   Provides a collection of hardware reservations for a given project.
 */
-func (a *Client) FindProjectHardwareReservations(params *FindProjectHardwareReservationsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectHardwareReservationsOK, error) {
+func (a *Client) FindProjectHardwareReservations(params *FindProjectHardwareReservationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectHardwareReservationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectHardwareReservationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectHardwareReservations",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/hardware-reservations",
@@ -775,7 +845,12 @@ func (a *Client) FindProjectHardwareReservations(params *FindProjectHardwareRese
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -794,13 +869,12 @@ func (a *Client) FindProjectHardwareReservations(params *FindProjectHardwareRese
 
   Provides a collection of licenses for a given project.
 */
-func (a *Client) FindProjectLicenses(params *FindProjectLicensesParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectLicensesOK, error) {
+func (a *Client) FindProjectLicenses(params *FindProjectLicensesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectLicensesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectLicensesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectLicenses",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/licenses",
@@ -812,7 +886,12 @@ func (a *Client) FindProjectLicenses(params *FindProjectLicensesParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -831,13 +910,12 @@ func (a *Client) FindProjectLicenses(params *FindProjectLicensesParams, authInfo
 
   Returns all memberships in a project.
 */
-func (a *Client) FindProjectMemberships(params *FindProjectMembershipsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectMembershipsOK, error) {
+func (a *Client) FindProjectMemberships(params *FindProjectMembershipsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectMembershipsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectMembershipsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectMemberships",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/memberships",
@@ -849,7 +927,12 @@ func (a *Client) FindProjectMemberships(params *FindProjectMembershipsParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -868,13 +951,12 @@ func (a *Client) FindProjectMemberships(params *FindProjectMembershipsParams, au
 
   Returns a collection of the project's ssh keys.
 */
-func (a *Client) FindProjectSSHKeys(params *FindProjectSSHKeysParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectSSHKeysOK, error) {
+func (a *Client) FindProjectSSHKeys(params *FindProjectSSHKeysParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectSSHKeysOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectSSHKeysParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjectSSHKeys",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/ssh-keys",
@@ -886,7 +968,12 @@ func (a *Client) FindProjectSSHKeys(params *FindProjectSSHKeysParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -905,13 +992,12 @@ func (a *Client) FindProjectSSHKeys(params *FindProjectSSHKeysParams, authInfo r
 
   Returns a collection of projects that the current user is a member of.
 */
-func (a *Client) FindProjects(params *FindProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*FindProjectsOK, error) {
+func (a *Client) FindProjects(params *FindProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindProjectsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindProjectsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findProjects",
 		Method:             "GET",
 		PathPattern:        "/projects",
@@ -923,7 +1009,12 @@ func (a *Client) FindProjects(params *FindProjectsParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -942,13 +1033,12 @@ func (a *Client) FindProjects(params *FindProjectsParams, authInfo runtime.Clien
 
   Provides a list of virtual networks for a single project.
 */
-func (a *Client) FindVirtualNetworks(params *FindVirtualNetworksParams, authInfo runtime.ClientAuthInfoWriter) (*FindVirtualNetworksOK, error) {
+func (a *Client) FindVirtualNetworks(params *FindVirtualNetworksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVirtualNetworksOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVirtualNetworksParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVirtualNetworks",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/virtual-networks",
@@ -960,7 +1050,12 @@ func (a *Client) FindVirtualNetworks(params *FindVirtualNetworksParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -979,13 +1074,12 @@ func (a *Client) FindVirtualNetworks(params *FindVirtualNetworksParams, authInfo
 
   View all spot market requests for a given project.
 */
-func (a *Client) ListSpotMarketRequests(params *ListSpotMarketRequestsParams, authInfo runtime.ClientAuthInfoWriter) (*ListSpotMarketRequestsOK, error) {
+func (a *Client) ListSpotMarketRequests(params *ListSpotMarketRequestsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListSpotMarketRequestsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListSpotMarketRequestsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listSpotMarketRequests",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/spot-market-requests",
@@ -997,7 +1091,12 @@ func (a *Client) ListSpotMarketRequests(params *ListSpotMarketRequestsParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1016,13 +1115,12 @@ func (a *Client) ListSpotMarketRequests(params *ListSpotMarketRequestsParams, au
 
   Requests to enable bgp configuration for a project.
 */
-func (a *Client) RequestBGPConfig(params *RequestBGPConfigParams, authInfo runtime.ClientAuthInfoWriter) (*RequestBGPConfigNoContent, error) {
+func (a *Client) RequestBGPConfig(params *RequestBGPConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RequestBGPConfigNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRequestBGPConfigParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "requestBgpConfig",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/bgp-configs",
@@ -1034,7 +1132,12 @@ func (a *Client) RequestBGPConfig(params *RequestBGPConfigParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1053,13 +1156,12 @@ func (a *Client) RequestBGPConfig(params *RequestBGPConfigParams, authInfo runti
 
   Request more IP space for a project in order to have additional IP addresses to assign to devices.  If the request is within the max quota, an IP reservation will be created. If the project will exceed its IP quota, a request will be submitted for review, and will return an IP Reservation with a `state` of `pending`. You can automatically have the request fail with HTTP status 422 instead of triggering the review process by providing the `fail_on_approval_required` parameter set to `true` in the request.
 */
-func (a *Client) RequestIPReservation(params *RequestIPReservationParams, authInfo runtime.ClientAuthInfoWriter) (*RequestIPReservationCreated, error) {
+func (a *Client) RequestIPReservation(params *RequestIPReservationParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RequestIPReservationCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRequestIPReservationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "requestIPReservation",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/ips",
@@ -1071,7 +1173,12 @@ func (a *Client) RequestIPReservation(params *RequestIPReservationParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1090,13 +1197,12 @@ func (a *Client) RequestIPReservation(params *RequestIPReservationParams, authIn
 
   Updates the project.
 */
-func (a *Client) UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateProjectOK, error) {
+func (a *Client) UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateProject",
 		Method:             "PUT",
 		PathPattern:        "/projects/{id}",
@@ -1108,7 +1214,12 @@ func (a *Client) UpdateProject(params *UpdateProjectParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/regions/regions_client.go
+++ b/client/regions/regions_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindRegions(params *FindRegionsParams, authInfo runtime.ClientAuthInfoWriter) (*FindRegionsOK, error)
+	FindRegions(params *FindRegionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindRegionsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -37,13 +40,12 @@ type ClientService interface {
 
   Returns all regions.
 */
-func (a *Client) FindRegions(params *FindRegionsParams, authInfo runtime.ClientAuthInfoWriter) (*FindRegionsOK, error) {
+func (a *Client) FindRegions(params *FindRegionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindRegionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindRegionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findRegions",
 		Method:             "GET",
 		PathPattern:        "/regions",
@@ -55,7 +57,12 @@ func (a *Client) FindRegions(params *FindRegionsParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/spot_market_request/spot_market_request_client.go
+++ b/client/spot_market_request/spot_market_request_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteSpotMarketRequest(params *DeleteSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteSpotMarketRequestNoContent, error)
+	DeleteSpotMarketRequest(params *DeleteSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteSpotMarketRequestNoContent, error)
 
-	FindSpotMarketRequestByID(params *FindSpotMarketRequestByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindSpotMarketRequestByIDOK, error)
+	FindSpotMarketRequestByID(params *FindSpotMarketRequestByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSpotMarketRequestByIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Deletes the spot market request.
 */
-func (a *Client) DeleteSpotMarketRequest(params *DeleteSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteSpotMarketRequestNoContent, error) {
+func (a *Client) DeleteSpotMarketRequest(params *DeleteSpotMarketRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteSpotMarketRequestNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteSpotMarketRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteSpotMarketRequest",
 		Method:             "DELETE",
 		PathPattern:        "/spot-market-requests/{id}",
@@ -57,7 +59,12 @@ func (a *Client) DeleteSpotMarketRequest(params *DeleteSpotMarketRequestParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) DeleteSpotMarketRequest(params *DeleteSpotMarketRequestParams, 
 
   Returns a single spot market request
 */
-func (a *Client) FindSpotMarketRequestByID(params *FindSpotMarketRequestByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindSpotMarketRequestByIDOK, error) {
+func (a *Client) FindSpotMarketRequestByID(params *FindSpotMarketRequestByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSpotMarketRequestByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindSpotMarketRequestByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findSpotMarketRequestById",
 		Method:             "GET",
 		PathPattern:        "/spot-market-requests/{id}",
@@ -94,7 +100,12 @@ func (a *Client) FindSpotMarketRequestByID(params *FindSpotMarketRequestByIDPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/ssh_keys/ssh_keys_client.go
+++ b/client/ssh_keys/ssh_keys_client.go
@@ -25,17 +25,20 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateSSHKey(params *CreateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*CreateSSHKeyCreated, error)
+	CreateSSHKey(params *CreateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateSSHKeyCreated, error)
 
-	DeleteSSHKey(params *DeleteSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteSSHKeyNoContent, error)
+	DeleteSSHKey(params *DeleteSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteSSHKeyNoContent, error)
 
-	FindSSHKeyByID(params *FindSSHKeyByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindSSHKeyByIDOK, error)
+	FindSSHKeyByID(params *FindSSHKeyByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSSHKeyByIDOK, error)
 
-	FindSSHKeys(params *FindSSHKeysParams, authInfo runtime.ClientAuthInfoWriter) (*FindSSHKeysOK, error)
+	FindSSHKeys(params *FindSSHKeysParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSSHKeysOK, error)
 
-	UpdateSSHKey(params *UpdateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateSSHKeyOK, error)
+	UpdateSSHKey(params *UpdateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateSSHKeyOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -45,13 +48,12 @@ type ClientService interface {
 
   Creates a ssh key.
 */
-func (a *Client) CreateSSHKey(params *CreateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*CreateSSHKeyCreated, error) {
+func (a *Client) CreateSSHKey(params *CreateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateSSHKeyCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateSSHKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createSSHKey",
 		Method:             "POST",
 		PathPattern:        "/ssh-keys",
@@ -63,7 +65,12 @@ func (a *Client) CreateSSHKey(params *CreateSSHKeyParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +89,12 @@ func (a *Client) CreateSSHKey(params *CreateSSHKeyParams, authInfo runtime.Clien
 
   Deletes the ssh key.
 */
-func (a *Client) DeleteSSHKey(params *DeleteSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteSSHKeyNoContent, error) {
+func (a *Client) DeleteSSHKey(params *DeleteSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteSSHKeyNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteSSHKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteSSHKey",
 		Method:             "DELETE",
 		PathPattern:        "/ssh-keys/{id}",
@@ -100,7 +106,12 @@ func (a *Client) DeleteSSHKey(params *DeleteSSHKeyParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -119,13 +130,12 @@ func (a *Client) DeleteSSHKey(params *DeleteSSHKeyParams, authInfo runtime.Clien
 
   Returns a single ssh key if the user has access
 */
-func (a *Client) FindSSHKeyByID(params *FindSSHKeyByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindSSHKeyByIDOK, error) {
+func (a *Client) FindSSHKeyByID(params *FindSSHKeyByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSSHKeyByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindSSHKeyByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findSSHKeyById",
 		Method:             "GET",
 		PathPattern:        "/ssh-keys/{id}",
@@ -137,7 +147,12 @@ func (a *Client) FindSSHKeyByID(params *FindSSHKeyByIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +171,12 @@ func (a *Client) FindSSHKeyByID(params *FindSSHKeyByIDParams, authInfo runtime.C
 
   Returns a collection of the user’s ssh keys.
 */
-func (a *Client) FindSSHKeys(params *FindSSHKeysParams, authInfo runtime.ClientAuthInfoWriter) (*FindSSHKeysOK, error) {
+func (a *Client) FindSSHKeys(params *FindSSHKeysParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindSSHKeysOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindSSHKeysParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findSSHKeys",
 		Method:             "GET",
 		PathPattern:        "/ssh-keys",
@@ -174,7 +188,12 @@ func (a *Client) FindSSHKeys(params *FindSSHKeysParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -193,13 +212,12 @@ func (a *Client) FindSSHKeys(params *FindSSHKeysParams, authInfo runtime.ClientA
 
   Updates the ssh key.
 */
-func (a *Client) UpdateSSHKey(params *UpdateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateSSHKeyOK, error) {
+func (a *Client) UpdateSSHKey(params *UpdateSSHKeyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateSSHKeyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateSSHKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateSSHKey",
 		Method:             "PUT",
 		PathPattern:        "/ssh-keys/{id}",
@@ -211,7 +229,12 @@ func (a *Client) UpdateSSHKey(params *UpdateSSHKeyParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/transfer_requests/transfer_requests_client.go
+++ b/client/transfer_requests/transfer_requests_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AcceptTransferRequest(params *AcceptTransferRequestParams, authInfo runtime.ClientAuthInfoWriter) (*AcceptTransferRequestNoContent, error)
+	AcceptTransferRequest(params *AcceptTransferRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AcceptTransferRequestNoContent, error)
 
-	DeclineTransferRequest(params *DeclineTransferRequestParams, authInfo runtime.ClientAuthInfoWriter) (*DeclineTransferRequestNoContent, error)
+	DeclineTransferRequest(params *DeclineTransferRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeclineTransferRequestNoContent, error)
 
-	FindTransferRequestByID(params *FindTransferRequestByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindTransferRequestByIDOK, error)
+	FindTransferRequestByID(params *FindTransferRequestByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindTransferRequestByIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Accept a transfer request.
 */
-func (a *Client) AcceptTransferRequest(params *AcceptTransferRequestParams, authInfo runtime.ClientAuthInfoWriter) (*AcceptTransferRequestNoContent, error) {
+func (a *Client) AcceptTransferRequest(params *AcceptTransferRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AcceptTransferRequestNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAcceptTransferRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "acceptTransferRequest",
 		Method:             "PUT",
 		PathPattern:        "/transfers/{id}",
@@ -59,7 +61,12 @@ func (a *Client) AcceptTransferRequest(params *AcceptTransferRequestParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) AcceptTransferRequest(params *AcceptTransferRequestParams, auth
 
   Decline a transfer request.
 */
-func (a *Client) DeclineTransferRequest(params *DeclineTransferRequestParams, authInfo runtime.ClientAuthInfoWriter) (*DeclineTransferRequestNoContent, error) {
+func (a *Client) DeclineTransferRequest(params *DeclineTransferRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeclineTransferRequestNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeclineTransferRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "declineTransferRequest",
 		Method:             "DELETE",
 		PathPattern:        "/transfers/{id}",
@@ -96,7 +102,12 @@ func (a *Client) DeclineTransferRequest(params *DeclineTransferRequestParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) DeclineTransferRequest(params *DeclineTransferRequestParams, au
 
   Returns a single transfer request.
 */
-func (a *Client) FindTransferRequestByID(params *FindTransferRequestByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindTransferRequestByIDOK, error) {
+func (a *Client) FindTransferRequestByID(params *FindTransferRequestByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindTransferRequestByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindTransferRequestByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findTransferRequestById",
 		Method:             "GET",
 		PathPattern:        "/transfers/{id}",
@@ -133,7 +143,12 @@ func (a *Client) FindTransferRequestByID(params *FindTransferRequestByIDParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/two_factor_auth/two_factor_auth_client.go
+++ b/client/two_factor_auth/two_factor_auth_client.go
@@ -25,15 +25,18 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DisableTfaApp(params *DisableTfaAppParams, authInfo runtime.ClientAuthInfoWriter) (*DisableTfaAppNoContent, error)
+	DisableTfaApp(params *DisableTfaAppParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DisableTfaAppNoContent, error)
 
-	DisableTfaSms(params *DisableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter) (*DisableTfaSmsNoContent, error)
+	DisableTfaSms(params *DisableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DisableTfaSmsNoContent, error)
 
-	EnableTfaApp(params *EnableTfaAppParams, authInfo runtime.ClientAuthInfoWriter) (*EnableTfaAppOK, error)
+	EnableTfaApp(params *EnableTfaAppParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*EnableTfaAppOK, error)
 
-	EnableTfaSms(params *EnableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter) (*EnableTfaSmsOK, error)
+	EnableTfaSms(params *EnableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*EnableTfaSmsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,13 +46,12 @@ type ClientService interface {
 
   Disables two factor authentication.
 */
-func (a *Client) DisableTfaApp(params *DisableTfaAppParams, authInfo runtime.ClientAuthInfoWriter) (*DisableTfaAppNoContent, error) {
+func (a *Client) DisableTfaApp(params *DisableTfaAppParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DisableTfaAppNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDisableTfaAppParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "disableTfaApp",
 		Method:             "DELETE",
 		PathPattern:        "/user/otp/app",
@@ -61,7 +63,12 @@ func (a *Client) DisableTfaApp(params *DisableTfaAppParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +87,12 @@ func (a *Client) DisableTfaApp(params *DisableTfaAppParams, authInfo runtime.Cli
 
   Disables two factor authentication.
 */
-func (a *Client) DisableTfaSms(params *DisableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter) (*DisableTfaSmsNoContent, error) {
+func (a *Client) DisableTfaSms(params *DisableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DisableTfaSmsNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDisableTfaSmsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "disableTfaSms",
 		Method:             "DELETE",
 		PathPattern:        "/user/otp/sms",
@@ -98,7 +104,12 @@ func (a *Client) DisableTfaSms(params *DisableTfaSmsParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +128,12 @@ func (a *Client) DisableTfaSms(params *DisableTfaSmsParams, authInfo runtime.Cli
 
   Enables two factor authentication using authenticator app.
 */
-func (a *Client) EnableTfaApp(params *EnableTfaAppParams, authInfo runtime.ClientAuthInfoWriter) (*EnableTfaAppOK, error) {
+func (a *Client) EnableTfaApp(params *EnableTfaAppParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*EnableTfaAppOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewEnableTfaAppParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "enableTfaApp",
 		Method:             "POST",
 		PathPattern:        "/user/otp/app",
@@ -135,7 +145,12 @@ func (a *Client) EnableTfaApp(params *EnableTfaAppParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -154,13 +169,12 @@ func (a *Client) EnableTfaApp(params *EnableTfaAppParams, authInfo runtime.Clien
 
   Enables two factor authentication with sms.
 */
-func (a *Client) EnableTfaSms(params *EnableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter) (*EnableTfaSmsOK, error) {
+func (a *Client) EnableTfaSms(params *EnableTfaSmsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*EnableTfaSmsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewEnableTfaSmsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "enableTfaSms",
 		Method:             "POST",
 		PathPattern:        "/user/otp/sms",
@@ -172,7 +186,12 @@ func (a *Client) EnableTfaSms(params *EnableTfaSmsParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/user_verification_tokens/user_verification_tokens_client.go
+++ b/client/user_verification_tokens/user_verification_tokens_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	ConsumeVerificationRequest(params *ConsumeVerificationRequestParams, authInfo runtime.ClientAuthInfoWriter) (*ConsumeVerificationRequestOK, error)
+	ConsumeVerificationRequest(params *ConsumeVerificationRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ConsumeVerificationRequestOK, error)
 
-	CreateValidationRequest(params *CreateValidationRequestParams, authInfo runtime.ClientAuthInfoWriter) (*CreateValidationRequestCreated, error)
+	CreateValidationRequest(params *CreateValidationRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateValidationRequestCreated, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Consumes an email verification token and verifies the user associated with it.
 */
-func (a *Client) ConsumeVerificationRequest(params *ConsumeVerificationRequestParams, authInfo runtime.ClientAuthInfoWriter) (*ConsumeVerificationRequestOK, error) {
+func (a *Client) ConsumeVerificationRequest(params *ConsumeVerificationRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ConsumeVerificationRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewConsumeVerificationRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "consumeVerificationRequest",
 		Method:             "PUT",
 		PathPattern:        "/verify-email",
@@ -57,7 +59,12 @@ func (a *Client) ConsumeVerificationRequest(params *ConsumeVerificationRequestPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) ConsumeVerificationRequest(params *ConsumeVerificationRequestPa
 
   Creates an email verification request
 */
-func (a *Client) CreateValidationRequest(params *CreateValidationRequestParams, authInfo runtime.ClientAuthInfoWriter) (*CreateValidationRequestCreated, error) {
+func (a *Client) CreateValidationRequest(params *CreateValidationRequestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateValidationRequestCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateValidationRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createValidationRequest",
 		Method:             "POST",
 		PathPattern:        "/verify-email",
@@ -94,7 +100,12 @@ func (a *Client) CreateValidationRequest(params *CreateValidationRequestParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/userdata/userdata_client.go
+++ b/client/userdata/userdata_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	ValidateUserdata(params *ValidateUserdataParams, authInfo runtime.ClientAuthInfoWriter) (*ValidateUserdataNoContent, error)
+	ValidateUserdata(params *ValidateUserdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ValidateUserdataNoContent, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -37,13 +40,12 @@ type ClientService interface {
 
   Validates user data (Userdata)
 */
-func (a *Client) ValidateUserdata(params *ValidateUserdataParams, authInfo runtime.ClientAuthInfoWriter) (*ValidateUserdataNoContent, error) {
+func (a *Client) ValidateUserdata(params *ValidateUserdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ValidateUserdataNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewValidateUserdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "validateUserdata",
 		Method:             "POST",
 		PathPattern:        "/userdata/validate",
@@ -55,7 +57,12 @@ func (a *Client) ValidateUserdata(params *ValidateUserdataParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/users/users_client.go
+++ b/client/users/users_client.go
@@ -25,17 +25,20 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindCurrentUser(params *FindCurrentUserParams, authInfo runtime.ClientAuthInfoWriter) (*FindCurrentUserOK, error)
+	FindCurrentUser(params *FindCurrentUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindCurrentUserOK, error)
 
-	FindUserByID(params *FindUserByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindUserByIDOK, error)
+	FindUserByID(params *FindUserByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindUserByIDOK, error)
 
-	FindUserCustomdata(params *FindUserCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindUserCustomdataOK, error)
+	FindUserCustomdata(params *FindUserCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindUserCustomdataOK, error)
 
-	FindUsers(params *FindUsersParams, authInfo runtime.ClientAuthInfoWriter) (*FindUsersOK, error)
+	FindUsers(params *FindUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindUsersOK, error)
 
-	UpdateCurrentUser(params *UpdateCurrentUserParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateCurrentUserOK, error)
+	UpdateCurrentUser(params *UpdateCurrentUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateCurrentUserOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -45,13 +48,12 @@ type ClientService interface {
 
   Returns the user object for the currently logged-in user.
 */
-func (a *Client) FindCurrentUser(params *FindCurrentUserParams, authInfo runtime.ClientAuthInfoWriter) (*FindCurrentUserOK, error) {
+func (a *Client) FindCurrentUser(params *FindCurrentUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindCurrentUserOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindCurrentUserParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findCurrentUser",
 		Method:             "GET",
 		PathPattern:        "/user",
@@ -63,7 +65,12 @@ func (a *Client) FindCurrentUser(params *FindCurrentUserParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +89,12 @@ func (a *Client) FindCurrentUser(params *FindCurrentUserParams, authInfo runtime
 
   Returns a single user if the user has access
 */
-func (a *Client) FindUserByID(params *FindUserByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindUserByIDOK, error) {
+func (a *Client) FindUserByID(params *FindUserByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindUserByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindUserByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findUserById",
 		Method:             "GET",
 		PathPattern:        "/users/{id}",
@@ -100,7 +106,12 @@ func (a *Client) FindUserByID(params *FindUserByIDParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -119,13 +130,12 @@ func (a *Client) FindUserByID(params *FindUserByIDParams, authInfo runtime.Clien
 
   Provides the custom metadata stored for this user in json format
 */
-func (a *Client) FindUserCustomdata(params *FindUserCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindUserCustomdataOK, error) {
+func (a *Client) FindUserCustomdata(params *FindUserCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindUserCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindUserCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findUserCustomdata",
 		Method:             "GET",
 		PathPattern:        "/users/{id}/customdata",
@@ -137,7 +147,12 @@ func (a *Client) FindUserCustomdata(params *FindUserCustomdataParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +171,12 @@ func (a *Client) FindUserCustomdata(params *FindUserCustomdataParams, authInfo r
 
   Returns a list of users that the are accessible to the current user (all users in the current user’s projects, essentially).
 */
-func (a *Client) FindUsers(params *FindUsersParams, authInfo runtime.ClientAuthInfoWriter) (*FindUsersOK, error) {
+func (a *Client) FindUsers(params *FindUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindUsersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindUsersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findUsers",
 		Method:             "GET",
 		PathPattern:        "/users",
@@ -174,7 +188,12 @@ func (a *Client) FindUsers(params *FindUsersParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -193,13 +212,12 @@ func (a *Client) FindUsers(params *FindUsersParams, authInfo runtime.ClientAuthI
 
   Updates the currently logged-in user.
 */
-func (a *Client) UpdateCurrentUser(params *UpdateCurrentUserParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateCurrentUserOK, error) {
+func (a *Client) UpdateCurrentUser(params *UpdateCurrentUserParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateCurrentUserOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateCurrentUserParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateCurrentUser",
 		Method:             "PUT",
 		PathPattern:        "/user",
@@ -211,7 +229,12 @@ func (a *Client) UpdateCurrentUser(params *UpdateCurrentUserParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/v_l_a_ns/vla_ns_client.go
+++ b/client/v_l_a_ns/vla_ns_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteVirtualNetwork(params *DeleteVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVirtualNetworkOK, error)
+	DeleteVirtualNetwork(params *DeleteVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVirtualNetworkOK, error)
 
-	GetVirtualNetwork(params *GetVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter) (*GetVirtualNetworkOK, error)
+	GetVirtualNetwork(params *GetVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetVirtualNetworkOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Deletes a virtual network.
 */
-func (a *Client) DeleteVirtualNetwork(params *DeleteVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVirtualNetworkOK, error) {
+func (a *Client) DeleteVirtualNetwork(params *DeleteVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVirtualNetworkOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteVirtualNetworkParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteVirtualNetwork",
 		Method:             "DELETE",
 		PathPattern:        "/virtual-networks/{id}",
@@ -57,7 +59,12 @@ func (a *Client) DeleteVirtualNetwork(params *DeleteVirtualNetworkParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) DeleteVirtualNetwork(params *DeleteVirtualNetworkParams, authIn
 
   Get a virtual network.
 */
-func (a *Client) GetVirtualNetwork(params *GetVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter) (*GetVirtualNetworkOK, error) {
+func (a *Client) GetVirtualNetwork(params *GetVirtualNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetVirtualNetworkOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetVirtualNetworkParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getVirtualNetwork",
 		Method:             "GET",
 		PathPattern:        "/virtual-networks/{id}",
@@ -94,7 +100,12 @@ func (a *Client) GetVirtualNetwork(params *GetVirtualNetworkParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/volumes/volumes_client.go
+++ b/client/volumes/volumes_client.go
@@ -25,41 +25,44 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CloneVolume(params *CloneVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*CloneVolumeCreated, error)
+	CloneVolume(params *CloneVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CloneVolumeCreated, error)
 
-	CreateVolume(params *CreateVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVolumeCreated, error)
+	CreateVolume(params *CreateVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVolumeCreated, error)
 
-	CreateVolumeAttachment(params *CreateVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVolumeAttachmentCreated, error)
+	CreateVolumeAttachment(params *CreateVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVolumeAttachmentCreated, error)
 
-	CreateVolumeSnapshotPolicy(params *CreateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVolumeSnapshotPolicyCreated, error)
+	CreateVolumeSnapshotPolicy(params *CreateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVolumeSnapshotPolicyCreated, error)
 
-	DeleteVolume(params *DeleteVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeNoContent, error)
+	DeleteVolume(params *DeleteVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeNoContent, error)
 
-	DeleteVolumeAttachment(params *DeleteVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeAttachmentNoContent, error)
+	DeleteVolumeAttachment(params *DeleteVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeAttachmentNoContent, error)
 
-	DeleteVolumeSnapshot(params *DeleteVolumeSnapshotParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeSnapshotNoContent, error)
+	DeleteVolumeSnapshot(params *DeleteVolumeSnapshotParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeSnapshotNoContent, error)
 
-	DeleteVolumeSnapshotPolicy(params *DeleteVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeSnapshotPolicyNoContent, error)
+	DeleteVolumeSnapshotPolicy(params *DeleteVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeSnapshotPolicyNoContent, error)
 
-	FindVolumeAttachmentByID(params *FindVolumeAttachmentByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeAttachmentByIDOK, error)
+	FindVolumeAttachmentByID(params *FindVolumeAttachmentByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeAttachmentByIDOK, error)
 
-	FindVolumeAttachments(params *FindVolumeAttachmentsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeAttachmentsOK, error)
+	FindVolumeAttachments(params *FindVolumeAttachmentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeAttachmentsOK, error)
 
-	FindVolumeByID(params *FindVolumeByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeByIDOK, error)
+	FindVolumeByID(params *FindVolumeByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeByIDOK, error)
 
-	FindVolumeCustomdata(params *FindVolumeCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeCustomdataOK, error)
+	FindVolumeCustomdata(params *FindVolumeCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeCustomdataOK, error)
 
-	FindVolumeSnapshots(params *FindVolumeSnapshotsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeSnapshotsOK, error)
+	FindVolumeSnapshots(params *FindVolumeSnapshotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeSnapshotsOK, error)
 
-	FindVolumes(params *FindVolumesParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumesOK, error)
+	FindVolumes(params *FindVolumesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumesOK, error)
 
-	RestoreVolume(params *RestoreVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*RestoreVolumeOK, error)
+	RestoreVolume(params *RestoreVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RestoreVolumeOK, error)
 
-	UpdateVolume(params *UpdateVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateVolumeOK, error)
+	UpdateVolume(params *UpdateVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateVolumeOK, error)
 
-	UpdateVolumeSnapshotPolicy(params *UpdateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateVolumeSnapshotPolicyOK, error)
+	UpdateVolumeSnapshotPolicy(params *UpdateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateVolumeSnapshotPolicyOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -69,13 +72,12 @@ type ClientService interface {
 
   Clone your volume or snapshot into a new volume. To clone the volume, send an empty body. To promote a volume snapshot into a new volume, include the snapshot_timestamp attribute in the request body.
 */
-func (a *Client) CloneVolume(params *CloneVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*CloneVolumeCreated, error) {
+func (a *Client) CloneVolume(params *CloneVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CloneVolumeCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCloneVolumeParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "cloneVolume",
 		Method:             "POST",
 		PathPattern:        "/storage/{id}/clone",
@@ -87,7 +89,12 @@ func (a *Client) CloneVolume(params *CloneVolumeParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -109,13 +116,12 @@ func (a *Client) CloneVolume(params *CloneVolumeParams, authInfo runtime.ClientA
          "facility": "ams1", "ewr1", "nrt1", "sjc1"
          "plan": "storage_1" (Standard), "storage_2" (Performance)
 */
-func (a *Client) CreateVolume(params *CreateVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVolumeCreated, error) {
+func (a *Client) CreateVolume(params *CreateVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVolumeCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateVolumeParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createVolume",
 		Method:             "POST",
 		PathPattern:        "/projects/{id}/storage",
@@ -127,7 +133,12 @@ func (a *Client) CreateVolume(params *CreateVolumeParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -146,13 +157,12 @@ func (a *Client) CreateVolume(params *CreateVolumeParams, authInfo runtime.Clien
 
   Attach your volume to a device.
 */
-func (a *Client) CreateVolumeAttachment(params *CreateVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVolumeAttachmentCreated, error) {
+func (a *Client) CreateVolumeAttachment(params *CreateVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVolumeAttachmentCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateVolumeAttachmentParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createVolumeAttachment",
 		Method:             "POST",
 		PathPattern:        "/storage/{id}/attachments",
@@ -164,7 +174,12 @@ func (a *Client) CreateVolumeAttachment(params *CreateVolumeAttachmentParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -183,13 +198,12 @@ func (a *Client) CreateVolumeAttachment(params *CreateVolumeAttachmentParams, au
 
   Creates a new snapshot policy of your volume.
 */
-func (a *Client) CreateVolumeSnapshotPolicy(params *CreateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*CreateVolumeSnapshotPolicyCreated, error) {
+func (a *Client) CreateVolumeSnapshotPolicy(params *CreateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateVolumeSnapshotPolicyCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateVolumeSnapshotPolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createVolumeSnapshotPolicy",
 		Method:             "POST",
 		PathPattern:        "/storage/{id}/snapshot-policies",
@@ -201,7 +215,12 @@ func (a *Client) CreateVolumeSnapshotPolicy(params *CreateVolumeSnapshotPolicyPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -220,13 +239,12 @@ func (a *Client) CreateVolumeSnapshotPolicy(params *CreateVolumeSnapshotPolicyPa
 
   Deletes the volume.
 */
-func (a *Client) DeleteVolume(params *DeleteVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeNoContent, error) {
+func (a *Client) DeleteVolume(params *DeleteVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteVolumeParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteVolume",
 		Method:             "DELETE",
 		PathPattern:        "/storage/{id}",
@@ -238,7 +256,12 @@ func (a *Client) DeleteVolume(params *DeleteVolumeParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -257,13 +280,12 @@ func (a *Client) DeleteVolume(params *DeleteVolumeParams, authInfo runtime.Clien
 
   Detach volume.
 */
-func (a *Client) DeleteVolumeAttachment(params *DeleteVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeAttachmentNoContent, error) {
+func (a *Client) DeleteVolumeAttachment(params *DeleteVolumeAttachmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeAttachmentNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteVolumeAttachmentParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteVolumeAttachment",
 		Method:             "DELETE",
 		PathPattern:        "/storage/attachments/{id}",
@@ -275,7 +297,12 @@ func (a *Client) DeleteVolumeAttachment(params *DeleteVolumeAttachmentParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -294,13 +321,12 @@ func (a *Client) DeleteVolumeAttachment(params *DeleteVolumeAttachmentParams, au
 
   Delete volume snapshot.
 */
-func (a *Client) DeleteVolumeSnapshot(params *DeleteVolumeSnapshotParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeSnapshotNoContent, error) {
+func (a *Client) DeleteVolumeSnapshot(params *DeleteVolumeSnapshotParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeSnapshotNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteVolumeSnapshotParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteVolumeSnapshot",
 		Method:             "DELETE",
 		PathPattern:        "/storage/{volume_id}/snapshots/{id}",
@@ -312,7 +338,12 @@ func (a *Client) DeleteVolumeSnapshot(params *DeleteVolumeSnapshotParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -331,13 +362,12 @@ func (a *Client) DeleteVolumeSnapshot(params *DeleteVolumeSnapshotParams, authIn
 
   Deletes the volume snapshot policy.
 */
-func (a *Client) DeleteVolumeSnapshotPolicy(params *DeleteVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteVolumeSnapshotPolicyNoContent, error) {
+func (a *Client) DeleteVolumeSnapshotPolicy(params *DeleteVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteVolumeSnapshotPolicyNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteVolumeSnapshotPolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteVolumeSnapshotPolicy",
 		Method:             "DELETE",
 		PathPattern:        "/storage/snapshot-policies/{id}",
@@ -349,7 +379,12 @@ func (a *Client) DeleteVolumeSnapshotPolicy(params *DeleteVolumeSnapshotPolicyPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -368,13 +403,12 @@ func (a *Client) DeleteVolumeSnapshotPolicy(params *DeleteVolumeSnapshotPolicyPa
 
   Returns a single attachment if the user has access
 */
-func (a *Client) FindVolumeAttachmentByID(params *FindVolumeAttachmentByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeAttachmentByIDOK, error) {
+func (a *Client) FindVolumeAttachmentByID(params *FindVolumeAttachmentByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeAttachmentByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumeAttachmentByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumeAttachmentById",
 		Method:             "GET",
 		PathPattern:        "/storage/attachments/{id}",
@@ -386,7 +420,12 @@ func (a *Client) FindVolumeAttachmentByID(params *FindVolumeAttachmentByIDParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -405,13 +444,12 @@ func (a *Client) FindVolumeAttachmentByID(params *FindVolumeAttachmentByIDParams
 
   Returns a list of the current volume’s attachments.
 */
-func (a *Client) FindVolumeAttachments(params *FindVolumeAttachmentsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeAttachmentsOK, error) {
+func (a *Client) FindVolumeAttachments(params *FindVolumeAttachmentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeAttachmentsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumeAttachmentsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumeAttachments",
 		Method:             "GET",
 		PathPattern:        "/storage/{id}/attachments",
@@ -423,7 +461,12 @@ func (a *Client) FindVolumeAttachments(params *FindVolumeAttachmentsParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -442,13 +485,12 @@ func (a *Client) FindVolumeAttachments(params *FindVolumeAttachmentsParams, auth
 
   Returns a single volume if the user has access
 */
-func (a *Client) FindVolumeByID(params *FindVolumeByIDParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeByIDOK, error) {
+func (a *Client) FindVolumeByID(params *FindVolumeByIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeByIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumeByIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumeById",
 		Method:             "GET",
 		PathPattern:        "/storage/{id}",
@@ -460,7 +502,12 @@ func (a *Client) FindVolumeByID(params *FindVolumeByIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -479,13 +526,12 @@ func (a *Client) FindVolumeByID(params *FindVolumeByIDParams, authInfo runtime.C
 
   Provides the custom metadata stored for this storage volume in json format
 */
-func (a *Client) FindVolumeCustomdata(params *FindVolumeCustomdataParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeCustomdataOK, error) {
+func (a *Client) FindVolumeCustomdata(params *FindVolumeCustomdataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeCustomdataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumeCustomdataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumeCustomdata",
 		Method:             "GET",
 		PathPattern:        "/storage/{id}/customdata",
@@ -497,7 +543,12 @@ func (a *Client) FindVolumeCustomdata(params *FindVolumeCustomdataParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -516,13 +567,12 @@ func (a *Client) FindVolumeCustomdata(params *FindVolumeCustomdataParams, authIn
 
   Returns a list of the current volume’s snapshots. To create Volume Snapshots, please check the Volume Snapshot Policies feature.
 */
-func (a *Client) FindVolumeSnapshots(params *FindVolumeSnapshotsParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumeSnapshotsOK, error) {
+func (a *Client) FindVolumeSnapshots(params *FindVolumeSnapshotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumeSnapshotsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumeSnapshotsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumeSnapshots",
 		Method:             "GET",
 		PathPattern:        "/storage/{id}/snapshots",
@@ -534,7 +584,12 @@ func (a *Client) FindVolumeSnapshots(params *FindVolumeSnapshotsParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -553,13 +608,12 @@ func (a *Client) FindVolumeSnapshots(params *FindVolumeSnapshotsParams, authInfo
 
   Returns a list of the current projects’s volumes.
 */
-func (a *Client) FindVolumes(params *FindVolumesParams, authInfo runtime.ClientAuthInfoWriter) (*FindVolumesOK, error) {
+func (a *Client) FindVolumes(params *FindVolumesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindVolumesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindVolumesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findVolumes",
 		Method:             "GET",
 		PathPattern:        "/projects/{id}/storage",
@@ -571,7 +625,12 @@ func (a *Client) FindVolumes(params *FindVolumesParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -590,13 +649,12 @@ func (a *Client) FindVolumes(params *FindVolumesParams, authInfo runtime.ClientA
 
   Restore the volume to the given snapshot.
 */
-func (a *Client) RestoreVolume(params *RestoreVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*RestoreVolumeOK, error) {
+func (a *Client) RestoreVolume(params *RestoreVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RestoreVolumeOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRestoreVolumeParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "restoreVolume",
 		Method:             "POST",
 		PathPattern:        "/storage/{id}/restore",
@@ -608,7 +666,12 @@ func (a *Client) RestoreVolume(params *RestoreVolumeParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -627,13 +690,12 @@ func (a *Client) RestoreVolume(params *RestoreVolumeParams, authInfo runtime.Cli
 
   Updates the volume.
 */
-func (a *Client) UpdateVolume(params *UpdateVolumeParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateVolumeOK, error) {
+func (a *Client) UpdateVolume(params *UpdateVolumeParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateVolumeOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateVolumeParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateVolume",
 		Method:             "PUT",
 		PathPattern:        "/storage/{id}",
@@ -645,7 +707,12 @@ func (a *Client) UpdateVolume(params *UpdateVolumeParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -664,13 +731,12 @@ func (a *Client) UpdateVolume(params *UpdateVolumeParams, authInfo runtime.Clien
 
   Updates the volume snapshot policy.
 */
-func (a *Client) UpdateVolumeSnapshotPolicy(params *UpdateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateVolumeSnapshotPolicyOK, error) {
+func (a *Client) UpdateVolumeSnapshotPolicy(params *UpdateVolumeSnapshotPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateVolumeSnapshotPolicyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateVolumeSnapshotPolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateVolumeSnapshotPolicy",
 		Method:             "PUT",
 		PathPattern:        "/storage/snapshot-policies/{id}",
@@ -682,7 +748,12 @@ func (a *Client) UpdateVolumeSnapshotPolicy(params *UpdateVolumeSnapshotPolicyPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/client/vpn/vpn_client.go
+++ b/client/vpn/vpn_client.go
@@ -25,13 +25,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	FindCurrentUserVPNConfig(params *FindCurrentUserVPNConfigParams, authInfo runtime.ClientAuthInfoWriter) (*FindCurrentUserVPNConfigOK, error)
+	FindCurrentUserVPNConfig(params *FindCurrentUserVPNConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindCurrentUserVPNConfigOK, error)
 
-	TurnOffCurrentUserVPN(params *TurnOffCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter) (*TurnOffCurrentUserVPNNoContent, error)
+	TurnOffCurrentUserVPN(params *TurnOffCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*TurnOffCurrentUserVPNNoContent, error)
 
-	TurnOnCurrentUserVPN(params *TurnOnCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter) (*TurnOnCurrentUserVPNCreated, error)
+	TurnOnCurrentUserVPN(params *TurnOnCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*TurnOnCurrentUserVPNCreated, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -41,13 +44,12 @@ type ClientService interface {
 
   Returns the client vpn config for the currently logged-in user.
 */
-func (a *Client) FindCurrentUserVPNConfig(params *FindCurrentUserVPNConfigParams, authInfo runtime.ClientAuthInfoWriter) (*FindCurrentUserVPNConfigOK, error) {
+func (a *Client) FindCurrentUserVPNConfig(params *FindCurrentUserVPNConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*FindCurrentUserVPNConfigOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFindCurrentUserVPNConfigParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "findCurrentUserVpnConfig",
 		Method:             "GET",
 		PathPattern:        "/user/vpn",
@@ -59,7 +61,12 @@ func (a *Client) FindCurrentUserVPNConfig(params *FindCurrentUserVPNConfigParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +85,12 @@ func (a *Client) FindCurrentUserVPNConfig(params *FindCurrentUserVPNConfigParams
 
   Turns off vpn for the currently logged-in user.
 */
-func (a *Client) TurnOffCurrentUserVPN(params *TurnOffCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter) (*TurnOffCurrentUserVPNNoContent, error) {
+func (a *Client) TurnOffCurrentUserVPN(params *TurnOffCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*TurnOffCurrentUserVPNNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewTurnOffCurrentUserVPNParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "turnOffCurrentUserVpn",
 		Method:             "DELETE",
 		PathPattern:        "/user/vpn",
@@ -96,7 +102,12 @@ func (a *Client) TurnOffCurrentUserVPN(params *TurnOffCurrentUserVPNParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -115,13 +126,12 @@ func (a *Client) TurnOffCurrentUserVPN(params *TurnOffCurrentUserVPNParams, auth
 
   Turns on vpn for the currently logged-in user.
 */
-func (a *Client) TurnOnCurrentUserVPN(params *TurnOnCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter) (*TurnOnCurrentUserVPNCreated, error) {
+func (a *Client) TurnOnCurrentUserVPN(params *TurnOnCurrentUserVPNParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*TurnOnCurrentUserVPNCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewTurnOnCurrentUserVPNParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "turnOnCurrentUserVpn",
 		Method:             "POST",
 		PathPattern:        "/user/vpn",
@@ -133,7 +143,12 @@ func (a *Client) TurnOnCurrentUserVPN(params *TurnOnCurrentUserVPNParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/equinix-metal.patched.json
+++ b/equinix-metal.patched.json
@@ -8711,12 +8711,18 @@
           }
         },
         "public_ipv4_subnet_size": {
+          "description": "Deprecated. Use ip_addresses. Subnet range for addresses allocated to this device. By default 1 address is allocated (subnet size 31). Your project must have addresses available for a non-default request.",
+          "example": 31,
           "type": "number",
-          "format": "integer"
+          "format": "integer",
+          "x-deprecated": true
         },
         "private_ipv4_subnet_size": {
+          "description": "Deprecated. Use ip_addresses. Subnet range for addresses allocated to this device. By default 1 address is allocated (subnet size 31).",
+          "example": 28,
           "type": "number",
-          "format": "integer"
+          "format": "integer",
+          "x-deprecated": true
         },
         "ip_addresses": {
           "type": "array",
@@ -8737,8 +8743,8 @@
               "cidr": {
                 "type": "number",
                 "format": "integer",
-                "description": "Cidr Size for the IP Block created. Valid values depends on the operating system been provisioned.",
-                "example": "28..32 for IPv4 addresses"
+                "description": "Cidr Size for the IP Block created. Valid values depends on the operating system being provisioned.",
+                "example": "28..31 for IPv4 addresses, 124..127 for IPv6 addresses."
               },
               "ip_reservations": {
                 "type": "array",

--- a/patches/05_deprecated-subnets.patch
+++ b/patches/05_deprecated-subnets.patch
@@ -1,0 +1,36 @@
+diff --git a/equinix-metal.patched.json b/equinix-metal.patched.json
+index 8808e45..a0058bc 100644
+--- a/equinix-metal.patched.json
++++ b/equinix-metal.patched.json
+@@ -8711,12 +8711,18 @@
+           }
+         },
+         "public_ipv4_subnet_size": {
++          "description": "Deprecated. Use ip_addresses. Subnet range for addresses allocated to this device. By default 1 address is allocated (subnet size 31). Your project must have addresses available for a non-default request.",
++          "example": 31,
+           "type": "number",
+-          "format": "integer"
++          "format": "integer",
++          "x-deprecated": true
+         },
+         "private_ipv4_subnet_size": {
++          "description": "Deprecated. Use ip_addresses. Subnet range for addresses allocated to this device. By default 1 address is allocated (subnet size 31).",
++          "example": 28,
+           "type": "number",
+-          "format": "integer"
++          "format": "integer",
++          "x-deprecated": true
+         },
+         "ip_addresses": {
+           "type": "array",
+@@ -8737,8 +8743,8 @@
+               "cidr": {
+                 "type": "number",
+                 "format": "integer",
+-                "description": "Cidr Size for the IP Block created. Valid values depends on the operating system been provisioned.",
+-                "example": "28..32 for IPv4 addresses"
++                "description": "Cidr Size for the IP Block created. Valid values depends on the operating system being provisioned.",
++                "example": "28..31 for IPv4 addresses, 124..127 for IPv6 addresses."
+               },
+               "ip_reservations": {
+                 "type": "array",

--- a/types/device_create_input.go
+++ b/types/device_create_input.go
@@ -64,13 +64,15 @@ type DeviceCreateInput struct {
 	// Required: true
 	Plan *string `json:"plan"`
 
-	// private ipv4 subnet size
+	// Deprecated. Use ip_addresses. Subnet range for addresses allocated to this device. By default 1 address is allocated (subnet size 31).
+	// Example: 28
 	PrivateIPV4SubnetSize int64 `json:"private_ipv4_subnet_size,omitempty"`
 
 	// project ssh keys
 	ProjectSSHKeys []strfmt.UUID `json:"project_ssh_keys"`
 
-	// public ipv4 subnet size
+	// Deprecated. Use ip_addresses. Subnet range for addresses allocated to this device. By default 1 address is allocated (subnet size 31). Your project must have addresses available for a non-default request.
+	// Example: 31
 	PublicIPV4SubnetSize int64 `json:"public_ipv4_subnet_size,omitempty"`
 
 	// spot instance
@@ -301,8 +303,8 @@ type DeviceCreateInputIPAddressesItems0 struct {
 	// Example: 4 or 6
 	AddressFamily int64 `json:"address_family,omitempty"`
 
-	// Cidr Size for the IP Block created. Valid values depends on the operating system been provisioned.
-	// Example: 28..32 for IPv4 addresses
+	// Cidr Size for the IP Block created. Valid values depends on the operating system being provisioned.
+	// Example: 28..31 for IPv4 addresses, 124..127 for IPv6 addresses.
 	Cidr int64 `json:"cidr,omitempty"`
 
 	// UUIDs of any IP reservations to use when assigning IPs


### PR DESCRIPTION
Adds a deprecation notice to the device create requests "subnet" fields which are less powerful that the `ip_addresses` fields.

Additionally, the `ip_addresses` fields take higher precedence when both fields are provided.